### PR TITLE
Small refactor to use FP idioms and HTTP calls via async.js.

### DIFF
--- a/src/main/resources/static/angular/ng-controllers.js
+++ b/src/main/resources/static/angular/ng-controllers.js
@@ -11,32 +11,49 @@ var pageTitle = function(baseTitle) {
 var homeController = function() {
 	var controller = function($scope, $http) {
 		$scope.model.page.title = pageTitle('Home');
-		serviceGroupsMap = {};
-		$http.get('/v1/service-groups').success(function(data) {
-			$scope.serviceGroups = data;
-			$scope.serviceGroups.push({ "key" : "_ungrouped", "name" : "Ungrouped" });
-			for (i = 0; i < data.length; i++) {
-				serviceGroup = data[i];
-				serviceGroup.services = [];
-				serviceGroupsMap[serviceGroup.key] = serviceGroup;
-			}
-		});
+		$scope.serviceStatus = 'loading';
 		
-		// FIXME If there are more than 300 services, we won't catch them all. We need a JS client for getting the
-		// full list from the paging API. (The API will continue to page.) [WLW]
-		$http.get('/v1/services?page=0&size=300&sort=name').success(function(data) {
-			services = data;
-			for (i = 0; i < services.length; i++) {
-				service = services[i];
-				group = service.group;
-				if (group === null) {
-					serviceGroupsMap['_ungrouped'].services.push(service);
-				} else {
-					serviceGroupsMap[group.key].services.push(service);
-				}
+		var getServiceGroups = function(doneCallback) {
+			$http.get('/v1/service-groups')
+				.success(function(serviceGroups) { return doneCallback(null, serviceGroups); })
+				.error(function(data) { return doneCallback(data, null); });
+		}
+		
+		var getServices = function(doneCallback) {
+			// FIXME If there are more than 300 services, we won't catch them all. We need a JS client for getting the
+			// full list from the paging API. (The API will continue to page.) [WLW]
+			$http.get('/v1/services?page=0&size=300&sort=name')
+				.success(function(services) { return doneCallback(null, services); })
+				.error(function(data) { return doneCallback(data, null); });
+		}
+		
+		var iterator = function(f, doneCallback) { f(doneCallback); }
+		async.map([getServiceGroups, getServices], iterator, function(err, results) {
+			if (err) {
+				$scope.serviceStatus = 'error';
+				return;
 			}
+			
+			var serviceGroups = results[0];
+			var services = results[1];
+			var serviceGroupsMap = {};
+			
+			serviceGroups.push({ "key" : "_ungrouped", "name" : "Ungrouped" });
+			serviceGroups.forEach(function(group) {
+				group.services = [];
+				serviceGroupsMap[group.key] = group;
+			});
+			
+			services.forEach(function(service) {
+				var key = (service.group === null ? '_ungrouped' : service.group.key);
+				serviceGroupsMap[key].services.push(service);
+			});
+			
+			$scope.serviceGroups = serviceGroups;
+			$scope.serviceStatus = 'loaded';
 		});
 	}
+	
 	return [ '$scope', '$http', controller ];
 }
 
@@ -170,7 +187,7 @@ var dataCenterDetailsController = function() {
 				$scope.loadBalancers = dataCenter._embedded.loadBalancers;
 				$scope.model.page.title = pageTitle(dataCenter.name);
 			}
-			var errorHandler = function(data) { alert("Error while getting data center."); }
+			var errorHandler = function() { alert("Error while getting data center."); }
 			v2Api.get('/v2/data-centers/' + $routeParams.key, successHandler, errorHandler);
 		})();
 		
@@ -393,7 +410,7 @@ var serviceInstanceDetailsController = function() {
 				$scope.checks = siEmbedded.seyrenChecks;
 			}
 			// TODO Do better error handling, like the examples below.
-			var errorHandler = function(data) { alert("Error while getting service instance."); }
+			var errorHandler = function() { alert("Error while getting service instance."); }
 			v2Api.get('/v2/service-instances/' + $routeParams.key, successHandler, errorHandler);
 		})();
 		

--- a/src/main/resources/static/bower.json
+++ b/src/main/resources/static/bower.json
@@ -11,6 +11,7 @@
     "angular-mocks": "~1.3.x",
     "angular-route": "~1.3.x",
     "angular-sanitize": "~1.3.x",
+    "async": "~0.2.5",
     "bootstrap": "3.2.0",
     "components-font-awesome": "4.3.0",
     "jquery": "1.9.1"

--- a/src/main/resources/static/bower/async/.bower.json
+++ b/src/main/resources/static/bower/async/.bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "async",
+  "homepage": "https://github.com/caolan/async",
+  "version": "0.2.10",
+  "_release": "0.2.10",
+  "_resolution": {
+    "type": "version",
+    "tag": "0.2.10",
+    "commit": "2d5bc3f5a6db2d699646e59a551355a21cd98637"
+  },
+  "_source": "git://github.com/caolan/async.git",
+  "_target": "~0.2.5",
+  "_originalSource": "async"
+}

--- a/src/main/resources/static/bower/async/.gitignore
+++ b/src/main/resources/static/bower/async/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/dist

--- a/src/main/resources/static/bower/async/.gitmodules
+++ b/src/main/resources/static/bower/async/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "deps/nodeunit"]
+	path = deps/nodeunit
+	url = git://github.com/caolan/nodeunit.git
+[submodule "deps/UglifyJS"]
+	path = deps/UglifyJS
+	url = https://github.com/mishoo/UglifyJS.git
+[submodule "deps/nodelint"]
+	path = deps/nodelint
+	url = https://github.com/tav/nodelint.git

--- a/src/main/resources/static/bower/async/.npmignore
+++ b/src/main/resources/static/bower/async/.npmignore
@@ -1,0 +1,7 @@
+deps
+dist
+test
+nodelint.cfg
+.npmignore
+.gitmodules
+Makefile

--- a/src/main/resources/static/bower/async/LICENSE
+++ b/src/main/resources/static/bower/async/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2010 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/main/resources/static/bower/async/Makefile
+++ b/src/main/resources/static/bower/async/Makefile
@@ -1,0 +1,25 @@
+PACKAGE = asyncjs
+NODEJS = $(if $(shell test -f /usr/bin/nodejs && echo "true"),nodejs,node)
+CWD := $(shell pwd)
+NODEUNIT = $(CWD)/node_modules/nodeunit/bin/nodeunit
+UGLIFY = $(CWD)/node_modules/uglify-js/bin/uglifyjs
+NODELINT = $(CWD)/node_modules/nodelint/nodelint
+
+BUILDDIR = dist
+
+all: clean test build
+
+build: $(wildcard  lib/*.js)
+	mkdir -p $(BUILDDIR)
+	$(UGLIFY) lib/async.js > $(BUILDDIR)/async.min.js
+
+test:
+	$(NODEUNIT) test
+
+clean:
+	rm -rf $(BUILDDIR)
+
+lint:
+	$(NODELINT) --config nodelint.cfg lib/async.js
+
+.PHONY: test build all

--- a/src/main/resources/static/bower/async/README.md
+++ b/src/main/resources/static/bower/async/README.md
@@ -1,0 +1,1425 @@
+# Async.js
+
+Async is a utility module which provides straight-forward, powerful functions
+for working with asynchronous JavaScript. Although originally designed for
+use with [node.js](http://nodejs.org), it can also be used directly in the
+browser. Also supports [component](https://github.com/component/component).
+
+Async provides around 20 functions that include the usual 'functional'
+suspects (map, reduce, filter, each…) as well as some common patterns
+for asynchronous control flow (parallel, series, waterfall…). All these
+functions assume you follow the node.js convention of providing a single
+callback as the last argument of your async function.
+
+
+## Quick Examples
+
+```javascript
+async.map(['file1','file2','file3'], fs.stat, function(err, results){
+    // results is now an array of stats for each file
+});
+
+async.filter(['file1','file2','file3'], fs.exists, function(results){
+    // results now equals an array of the existing files
+});
+
+async.parallel([
+    function(){ ... },
+    function(){ ... }
+], callback);
+
+async.series([
+    function(){ ... },
+    function(){ ... }
+]);
+```
+
+There are many more functions available so take a look at the docs below for a
+full list. This module aims to be comprehensive, so if you feel anything is
+missing please create a GitHub issue for it.
+
+## Common Pitfalls
+
+### Binding a context to an iterator
+
+This section is really about bind, not about async. If you are wondering how to
+make async execute your iterators in a given context, or are confused as to why
+a method of another library isn't working as an iterator, study this example:
+
+```js
+// Here is a simple object with an (unnecessarily roundabout) squaring method
+var AsyncSquaringLibrary = {
+  squareExponent: 2,
+  square: function(number, callback){ 
+    var result = Math.pow(number, this.squareExponent);
+    setTimeout(function(){
+      callback(null, result);
+    }, 200);
+  }
+};
+
+async.map([1, 2, 3], AsyncSquaringLibrary.square, function(err, result){
+  // result is [NaN, NaN, NaN]
+  // This fails because the `this.squareExponent` expression in the square
+  // function is not evaluated in the context of AsyncSquaringLibrary, and is
+  // therefore undefined.
+});
+
+async.map([1, 2, 3], AsyncSquaringLibrary.square.bind(AsyncSquaringLibrary), function(err, result){
+  // result is [1, 4, 9]
+  // With the help of bind we can attach a context to the iterator before
+  // passing it to async. Now the square function will be executed in its 
+  // 'home' AsyncSquaringLibrary context and the value of `this.squareExponent`
+  // will be as expected.
+});
+```
+
+## Download
+
+The source is available for download from
+[GitHub](http://github.com/caolan/async).
+Alternatively, you can install using Node Package Manager (npm):
+
+    npm install async
+
+__Development:__ [async.js](https://github.com/caolan/async/raw/master/lib/async.js) - 29.6kb Uncompressed
+
+## In the Browser
+
+So far it's been tested in IE6, IE7, IE8, FF3.6 and Chrome 5. Usage:
+
+```html
+<script type="text/javascript" src="async.js"></script>
+<script type="text/javascript">
+
+    async.map(data, asyncProcess, function(err, results){
+        alert(results);
+    });
+
+</script>
+```
+
+## Documentation
+
+### Collections
+
+* [each](#each)
+* [eachSeries](#eachSeries)
+* [eachLimit](#eachLimit)
+* [map](#map)
+* [mapSeries](#mapSeries)
+* [mapLimit](#mapLimit)
+* [filter](#filter)
+* [filterSeries](#filterSeries)
+* [reject](#reject)
+* [rejectSeries](#rejectSeries)
+* [reduce](#reduce)
+* [reduceRight](#reduceRight)
+* [detect](#detect)
+* [detectSeries](#detectSeries)
+* [sortBy](#sortBy)
+* [some](#some)
+* [every](#every)
+* [concat](#concat)
+* [concatSeries](#concatSeries)
+
+### Control Flow
+
+* [series](#series)
+* [parallel](#parallel)
+* [parallelLimit](#parallellimittasks-limit-callback)
+* [whilst](#whilst)
+* [doWhilst](#doWhilst)
+* [until](#until)
+* [doUntil](#doUntil)
+* [forever](#forever)
+* [waterfall](#waterfall)
+* [compose](#compose)
+* [applyEach](#applyEach)
+* [applyEachSeries](#applyEachSeries)
+* [queue](#queue)
+* [cargo](#cargo)
+* [auto](#auto)
+* [iterator](#iterator)
+* [apply](#apply)
+* [nextTick](#nextTick)
+* [times](#times)
+* [timesSeries](#timesSeries)
+
+### Utils
+
+* [memoize](#memoize)
+* [unmemoize](#unmemoize)
+* [log](#log)
+* [dir](#dir)
+* [noConflict](#noConflict)
+
+
+## Collections
+
+<a name="forEach" />
+<a name="each" />
+### each(arr, iterator, callback)
+
+Applies an iterator function to each item in an array, in parallel.
+The iterator is called with an item from the list and a callback for when it
+has finished. If the iterator passes an error to this callback, the main
+callback for the each function is immediately called with the error.
+
+Note, that since this function applies the iterator to each item in parallel
+there is no guarantee that the iterator functions will complete in order.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A function to apply to each item in the array.
+  The iterator is passed a callback(err) which must be called once it has 
+  completed. If no error has occured, the callback should be run without 
+  arguments or with an explicit null argument.
+* callback(err) - A callback which is called after all the iterator functions
+  have finished, or an error has occurred.
+
+__Example__
+
+```js
+// assuming openFiles is an array of file names and saveFile is a function
+// to save the modified contents of that file:
+
+async.each(openFiles, saveFile, function(err){
+    // if any of the saves produced an error, err would equal that error
+});
+```
+
+---------------------------------------
+
+<a name="forEachSeries" />
+<a name="eachSeries" />
+### eachSeries(arr, iterator, callback)
+
+The same as each only the iterator is applied to each item in the array in
+series. The next iterator is only called once the current one has completed
+processing. This means the iterator functions will complete in order.
+
+
+---------------------------------------
+
+<a name="forEachLimit" />
+<a name="eachLimit" />
+### eachLimit(arr, limit, iterator, callback)
+
+The same as each only no more than "limit" iterators will be simultaneously 
+running at any time.
+
+Note that the items are not processed in batches, so there is no guarantee that
+ the first "limit" iterator functions will complete before any others are 
+started.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* limit - The maximum number of iterators to run at any time.
+* iterator(item, callback) - A function to apply to each item in the array.
+  The iterator is passed a callback(err) which must be called once it has 
+  completed. If no error has occured, the callback should be run without 
+  arguments or with an explicit null argument.
+* callback(err) - A callback which is called after all the iterator functions
+  have finished, or an error has occurred.
+
+__Example__
+
+```js
+// Assume documents is an array of JSON objects and requestApi is a
+// function that interacts with a rate-limited REST api.
+
+async.eachLimit(documents, 20, requestApi, function(err){
+    // if any of the saves produced an error, err would equal that error
+});
+```
+
+---------------------------------------
+
+<a name="map" />
+### map(arr, iterator, callback)
+
+Produces a new array of values by mapping each value in the given array through
+the iterator function. The iterator is called with an item from the array and a
+callback for when it has finished processing. The callback takes 2 arguments, 
+an error and the transformed item from the array. If the iterator passes an
+error to this callback, the main callback for the map function is immediately
+called with the error.
+
+Note, that since this function applies the iterator to each item in parallel
+there is no guarantee that the iterator functions will complete in order, however
+the results array will be in the same order as the original array.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A function to apply to each item in the array.
+  The iterator is passed a callback(err, transformed) which must be called once 
+  it has completed with an error (which can be null) and a transformed item.
+* callback(err, results) - A callback which is called after all the iterator
+  functions have finished, or an error has occurred. Results is an array of the
+  transformed items from the original array.
+
+__Example__
+
+```js
+async.map(['file1','file2','file3'], fs.stat, function(err, results){
+    // results is now an array of stats for each file
+});
+```
+
+---------------------------------------
+
+<a name="mapSeries" />
+### mapSeries(arr, iterator, callback)
+
+The same as map only the iterator is applied to each item in the array in
+series. The next iterator is only called once the current one has completed
+processing. The results array will be in the same order as the original.
+
+
+---------------------------------------
+
+<a name="mapLimit" />
+### mapLimit(arr, limit, iterator, callback)
+
+The same as map only no more than "limit" iterators will be simultaneously 
+running at any time.
+
+Note that the items are not processed in batches, so there is no guarantee that
+ the first "limit" iterator functions will complete before any others are 
+started.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* limit - The maximum number of iterators to run at any time.
+* iterator(item, callback) - A function to apply to each item in the array.
+  The iterator is passed a callback(err, transformed) which must be called once 
+  it has completed with an error (which can be null) and a transformed item.
+* callback(err, results) - A callback which is called after all the iterator
+  functions have finished, or an error has occurred. Results is an array of the
+  transformed items from the original array.
+
+__Example__
+
+```js
+async.mapLimit(['file1','file2','file3'], 1, fs.stat, function(err, results){
+    // results is now an array of stats for each file
+});
+```
+
+---------------------------------------
+
+<a name="filter" />
+### filter(arr, iterator, callback)
+
+__Alias:__ select
+
+Returns a new array of all the values which pass an async truth test.
+_The callback for each iterator call only accepts a single argument of true or
+false, it does not accept an error argument first!_ This is in-line with the
+way node libraries work with truth tests like fs.exists. This operation is
+performed in parallel, but the results array will be in the same order as the
+original.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A truth test to apply to each item in the array.
+  The iterator is passed a callback(truthValue) which must be called with a 
+  boolean argument once it has completed.
+* callback(results) - A callback which is called after all the iterator
+  functions have finished.
+
+__Example__
+
+```js
+async.filter(['file1','file2','file3'], fs.exists, function(results){
+    // results now equals an array of the existing files
+});
+```
+
+---------------------------------------
+
+<a name="filterSeries" />
+### filterSeries(arr, iterator, callback)
+
+__alias:__ selectSeries
+
+The same as filter only the iterator is applied to each item in the array in
+series. The next iterator is only called once the current one has completed
+processing. The results array will be in the same order as the original.
+
+---------------------------------------
+
+<a name="reject" />
+### reject(arr, iterator, callback)
+
+The opposite of filter. Removes values that pass an async truth test.
+
+---------------------------------------
+
+<a name="rejectSeries" />
+### rejectSeries(arr, iterator, callback)
+
+The same as reject, only the iterator is applied to each item in the array
+in series.
+
+
+---------------------------------------
+
+<a name="reduce" />
+### reduce(arr, memo, iterator, callback)
+
+__aliases:__ inject, foldl
+
+Reduces a list of values into a single value using an async iterator to return
+each successive step. Memo is the initial state of the reduction. This
+function only operates in series. For performance reasons, it may make sense to
+split a call to this function into a parallel map, then use the normal
+Array.prototype.reduce on the results. This function is for situations where
+each step in the reduction needs to be async, if you can get the data before
+reducing it then it's probably a good idea to do so.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* memo - The initial state of the reduction.
+* iterator(memo, item, callback) - A function applied to each item in the
+  array to produce the next step in the reduction. The iterator is passed a
+  callback(err, reduction) which accepts an optional error as its first 
+  argument, and the state of the reduction as the second. If an error is 
+  passed to the callback, the reduction is stopped and the main callback is 
+  immediately called with the error.
+* callback(err, result) - A callback which is called after all the iterator
+  functions have finished. Result is the reduced value.
+
+__Example__
+
+```js
+async.reduce([1,2,3], 0, function(memo, item, callback){
+    // pointless async:
+    process.nextTick(function(){
+        callback(null, memo + item)
+    });
+}, function(err, result){
+    // result is now equal to the last value of memo, which is 6
+});
+```
+
+---------------------------------------
+
+<a name="reduceRight" />
+### reduceRight(arr, memo, iterator, callback)
+
+__Alias:__ foldr
+
+Same as reduce, only operates on the items in the array in reverse order.
+
+
+---------------------------------------
+
+<a name="detect" />
+### detect(arr, iterator, callback)
+
+Returns the first value in a list that passes an async truth test. The
+iterator is applied in parallel, meaning the first iterator to return true will
+fire the detect callback with that result. That means the result might not be
+the first item in the original array (in terms of order) that passes the test.
+
+If order within the original array is important then look at detectSeries.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A truth test to apply to each item in the array.
+  The iterator is passed a callback(truthValue) which must be called with a 
+  boolean argument once it has completed.
+* callback(result) - A callback which is called as soon as any iterator returns
+  true, or after all the iterator functions have finished. Result will be
+  the first item in the array that passes the truth test (iterator) or the
+  value undefined if none passed.
+
+__Example__
+
+```js
+async.detect(['file1','file2','file3'], fs.exists, function(result){
+    // result now equals the first file in the list that exists
+});
+```
+
+---------------------------------------
+
+<a name="detectSeries" />
+### detectSeries(arr, iterator, callback)
+
+The same as detect, only the iterator is applied to each item in the array
+in series. This means the result is always the first in the original array (in
+terms of array order) that passes the truth test.
+
+
+---------------------------------------
+
+<a name="sortBy" />
+### sortBy(arr, iterator, callback)
+
+Sorts a list by the results of running each value through an async iterator.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A function to apply to each item in the array.
+  The iterator is passed a callback(err, sortValue) which must be called once it
+  has completed with an error (which can be null) and a value to use as the sort
+  criteria.
+* callback(err, results) - A callback which is called after all the iterator
+  functions have finished, or an error has occurred. Results is the items from
+  the original array sorted by the values returned by the iterator calls.
+
+__Example__
+
+```js
+async.sortBy(['file1','file2','file3'], function(file, callback){
+    fs.stat(file, function(err, stats){
+        callback(err, stats.mtime);
+    });
+}, function(err, results){
+    // results is now the original array of files sorted by
+    // modified date
+});
+```
+
+---------------------------------------
+
+<a name="some" />
+### some(arr, iterator, callback)
+
+__Alias:__ any
+
+Returns true if at least one element in the array satisfies an async test.
+_The callback for each iterator call only accepts a single argument of true or
+false, it does not accept an error argument first!_ This is in-line with the
+way node libraries work with truth tests like fs.exists. Once any iterator
+call returns true, the main callback is immediately called.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A truth test to apply to each item in the array.
+  The iterator is passed a callback(truthValue) which must be called with a 
+  boolean argument once it has completed.
+* callback(result) - A callback which is called as soon as any iterator returns
+  true, or after all the iterator functions have finished. Result will be
+  either true or false depending on the values of the async tests.
+
+__Example__
+
+```js
+async.some(['file1','file2','file3'], fs.exists, function(result){
+    // if result is true then at least one of the files exists
+});
+```
+
+---------------------------------------
+
+<a name="every" />
+### every(arr, iterator, callback)
+
+__Alias:__ all
+
+Returns true if every element in the array satisfies an async test.
+_The callback for each iterator call only accepts a single argument of true or
+false, it does not accept an error argument first!_ This is in-line with the
+way node libraries work with truth tests like fs.exists.
+
+__Arguments__
+
+* arr - An array to iterate over.
+* iterator(item, callback) - A truth test to apply to each item in the array.
+  The iterator is passed a callback(truthValue) which must be called with a 
+  boolean argument once it has completed.
+* callback(result) - A callback which is called after all the iterator
+  functions have finished. Result will be either true or false depending on
+  the values of the async tests.
+
+__Example__
+
+```js
+async.every(['file1','file2','file3'], fs.exists, function(result){
+    // if result is true then every file exists
+});
+```
+
+---------------------------------------
+
+<a name="concat" />
+### concat(arr, iterator, callback)
+
+Applies an iterator to each item in a list, concatenating the results. Returns the
+concatenated list. The iterators are called in parallel, and the results are
+concatenated as they return. There is no guarantee that the results array will
+be returned in the original order of the arguments passed to the iterator function.
+
+__Arguments__
+
+* arr - An array to iterate over
+* iterator(item, callback) - A function to apply to each item in the array.
+  The iterator is passed a callback(err, results) which must be called once it 
+  has completed with an error (which can be null) and an array of results.
+* callback(err, results) - A callback which is called after all the iterator
+  functions have finished, or an error has occurred. Results is an array containing
+  the concatenated results of the iterator function.
+
+__Example__
+
+```js
+async.concat(['dir1','dir2','dir3'], fs.readdir, function(err, files){
+    // files is now a list of filenames that exist in the 3 directories
+});
+```
+
+---------------------------------------
+
+<a name="concatSeries" />
+### concatSeries(arr, iterator, callback)
+
+Same as async.concat, but executes in series instead of parallel.
+
+
+## Control Flow
+
+<a name="series" />
+### series(tasks, [callback])
+
+Run an array of functions in series, each one running once the previous
+function has completed. If any functions in the series pass an error to its
+callback, no more functions are run and the callback for the series is
+immediately called with the value of the error. Once the tasks have completed,
+the results are passed to the final callback as an array.
+
+It is also possible to use an object instead of an array. Each property will be
+run as a function and the results will be passed to the final callback as an object
+instead of an array. This can be a more readable way of handling results from
+async.series.
+
+
+__Arguments__
+
+* tasks - An array or object containing functions to run, each function is passed
+  a callback(err, result) it must call on completion with an error (which can
+  be null) and an optional result value.
+* callback(err, results) - An optional callback to run once all the functions
+  have completed. This function gets a results array (or object) containing all 
+  the result arguments passed to the task callbacks.
+
+__Example__
+
+```js
+async.series([
+    function(callback){
+        // do some stuff ...
+        callback(null, 'one');
+    },
+    function(callback){
+        // do some more stuff ...
+        callback(null, 'two');
+    }
+],
+// optional callback
+function(err, results){
+    // results is now equal to ['one', 'two']
+});
+
+
+// an example using an object instead of an array
+async.series({
+    one: function(callback){
+        setTimeout(function(){
+            callback(null, 1);
+        }, 200);
+    },
+    two: function(callback){
+        setTimeout(function(){
+            callback(null, 2);
+        }, 100);
+    }
+},
+function(err, results) {
+    // results is now equal to: {one: 1, two: 2}
+});
+```
+
+---------------------------------------
+
+<a name="parallel" />
+### parallel(tasks, [callback])
+
+Run an array of functions in parallel, without waiting until the previous
+function has completed. If any of the functions pass an error to its
+callback, the main callback is immediately called with the value of the error.
+Once the tasks have completed, the results are passed to the final callback as an
+array.
+
+It is also possible to use an object instead of an array. Each property will be
+run as a function and the results will be passed to the final callback as an object
+instead of an array. This can be a more readable way of handling results from
+async.parallel.
+
+
+__Arguments__
+
+* tasks - An array or object containing functions to run, each function is passed 
+  a callback(err, result) it must call on completion with an error (which can
+  be null) and an optional result value.
+* callback(err, results) - An optional callback to run once all the functions
+  have completed. This function gets a results array (or object) containing all 
+  the result arguments passed to the task callbacks.
+
+__Example__
+
+```js
+async.parallel([
+    function(callback){
+        setTimeout(function(){
+            callback(null, 'one');
+        }, 200);
+    },
+    function(callback){
+        setTimeout(function(){
+            callback(null, 'two');
+        }, 100);
+    }
+],
+// optional callback
+function(err, results){
+    // the results array will equal ['one','two'] even though
+    // the second function had a shorter timeout.
+});
+
+
+// an example using an object instead of an array
+async.parallel({
+    one: function(callback){
+        setTimeout(function(){
+            callback(null, 1);
+        }, 200);
+    },
+    two: function(callback){
+        setTimeout(function(){
+            callback(null, 2);
+        }, 100);
+    }
+},
+function(err, results) {
+    // results is now equals to: {one: 1, two: 2}
+});
+```
+
+---------------------------------------
+
+<a name="parallel" />
+### parallelLimit(tasks, limit, [callback])
+
+The same as parallel only the tasks are executed in parallel with a maximum of "limit" 
+tasks executing at any time.
+
+Note that the tasks are not executed in batches, so there is no guarantee that 
+the first "limit" tasks will complete before any others are started.
+
+__Arguments__
+
+* tasks - An array or object containing functions to run, each function is passed 
+  a callback(err, result) it must call on completion with an error (which can
+  be null) and an optional result value.
+* limit - The maximum number of tasks to run at any time.
+* callback(err, results) - An optional callback to run once all the functions
+  have completed. This function gets a results array (or object) containing all 
+  the result arguments passed to the task callbacks.
+
+---------------------------------------
+
+<a name="whilst" />
+### whilst(test, fn, callback)
+
+Repeatedly call fn, while test returns true. Calls the callback when stopped,
+or an error occurs.
+
+__Arguments__
+
+* test() - synchronous truth test to perform before each execution of fn.
+* fn(callback) - A function to call each time the test passes. The function is
+  passed a callback(err) which must be called once it has completed with an 
+  optional error argument.
+* callback(err) - A callback which is called after the test fails and repeated
+  execution of fn has stopped.
+
+__Example__
+
+```js
+var count = 0;
+
+async.whilst(
+    function () { return count < 5; },
+    function (callback) {
+        count++;
+        setTimeout(callback, 1000);
+    },
+    function (err) {
+        // 5 seconds have passed
+    }
+);
+```
+
+---------------------------------------
+
+<a name="doWhilst" />
+### doWhilst(fn, test, callback)
+
+The post check version of whilst. To reflect the difference in the order of operations `test` and `fn` arguments are switched. `doWhilst` is to `whilst` as `do while` is to `while` in plain JavaScript.
+
+---------------------------------------
+
+<a name="until" />
+### until(test, fn, callback)
+
+Repeatedly call fn, until test returns true. Calls the callback when stopped,
+or an error occurs.
+
+The inverse of async.whilst.
+
+---------------------------------------
+
+<a name="doUntil" />
+### doUntil(fn, test, callback)
+
+Like doWhilst except the test is inverted. Note the argument ordering differs from `until`.
+
+---------------------------------------
+
+<a name="forever" />
+### forever(fn, callback)
+
+Calls the asynchronous function 'fn' repeatedly, in series, indefinitely.
+If an error is passed to fn's callback then 'callback' is called with the
+error, otherwise it will never be called.
+
+---------------------------------------
+
+<a name="waterfall" />
+### waterfall(tasks, [callback])
+
+Runs an array of functions in series, each passing their results to the next in
+the array. However, if any of the functions pass an error to the callback, the
+next function is not executed and the main callback is immediately called with
+the error.
+
+__Arguments__
+
+* tasks - An array of functions to run, each function is passed a 
+  callback(err, result1, result2, ...) it must call on completion. The first
+  argument is an error (which can be null) and any further arguments will be 
+  passed as arguments in order to the next task.
+* callback(err, [results]) - An optional callback to run once all the functions
+  have completed. This will be passed the results of the last task's callback.
+
+
+
+__Example__
+
+```js
+async.waterfall([
+    function(callback){
+        callback(null, 'one', 'two');
+    },
+    function(arg1, arg2, callback){
+        callback(null, 'three');
+    },
+    function(arg1, callback){
+        // arg1 now equals 'three'
+        callback(null, 'done');
+    }
+], function (err, result) {
+   // result now equals 'done'    
+});
+```
+
+---------------------------------------
+<a name="compose" />
+### compose(fn1, fn2...)
+
+Creates a function which is a composition of the passed asynchronous
+functions. Each function consumes the return value of the function that
+follows. Composing functions f(), g() and h() would produce the result of
+f(g(h())), only this version uses callbacks to obtain the return values.
+
+Each function is executed with the `this` binding of the composed function.
+
+__Arguments__
+
+* functions... - the asynchronous functions to compose
+
+
+__Example__
+
+```js
+function add1(n, callback) {
+    setTimeout(function () {
+        callback(null, n + 1);
+    }, 10);
+}
+
+function mul3(n, callback) {
+    setTimeout(function () {
+        callback(null, n * 3);
+    }, 10);
+}
+
+var add1mul3 = async.compose(mul3, add1);
+
+add1mul3(4, function (err, result) {
+   // result now equals 15
+});
+```
+
+---------------------------------------
+<a name="applyEach" />
+### applyEach(fns, args..., callback)
+
+Applies the provided arguments to each function in the array, calling the
+callback after all functions have completed. If you only provide the first
+argument then it will return a function which lets you pass in the
+arguments as if it were a single function call.
+
+__Arguments__
+
+* fns - the asynchronous functions to all call with the same arguments
+* args... - any number of separate arguments to pass to the function
+* callback - the final argument should be the callback, called when all
+  functions have completed processing
+
+
+__Example__
+
+```js
+async.applyEach([enableSearch, updateSchema], 'bucket', callback);
+
+// partial application example:
+async.each(
+    buckets,
+    async.applyEach([enableSearch, updateSchema]),
+    callback
+);
+```
+
+---------------------------------------
+
+<a name="applyEachSeries" />
+### applyEachSeries(arr, iterator, callback)
+
+The same as applyEach only the functions are applied in series.
+
+---------------------------------------
+
+<a name="queue" />
+### queue(worker, concurrency)
+
+Creates a queue object with the specified concurrency. Tasks added to the
+queue will be processed in parallel (up to the concurrency limit). If all
+workers are in progress, the task is queued until one is available. Once
+a worker has completed a task, the task's callback is called.
+
+__Arguments__
+
+* worker(task, callback) - An asynchronous function for processing a queued
+  task, which must call its callback(err) argument when finished, with an 
+  optional error as an argument.
+* concurrency - An integer for determining how many worker functions should be
+  run in parallel.
+
+__Queue objects__
+
+The queue object returned by this function has the following properties and
+methods:
+
+* length() - a function returning the number of items waiting to be processed.
+* concurrency - an integer for determining how many worker functions should be
+  run in parallel. This property can be changed after a queue is created to
+  alter the concurrency on-the-fly.
+* push(task, [callback]) - add a new task to the queue, the callback is called
+  once the worker has finished processing the task.
+  instead of a single task, an array of tasks can be submitted. the respective callback is used for every task in the list.
+* unshift(task, [callback]) - add a new task to the front of the queue.
+* saturated - a callback that is called when the queue length hits the concurrency and further tasks will be queued
+* empty - a callback that is called when the last item from the queue is given to a worker
+* drain - a callback that is called when the last item from the queue has returned from the worker
+
+__Example__
+
+```js
+// create a queue object with concurrency 2
+
+var q = async.queue(function (task, callback) {
+    console.log('hello ' + task.name);
+    callback();
+}, 2);
+
+
+// assign a callback
+q.drain = function() {
+    console.log('all items have been processed');
+}
+
+// add some items to the queue
+
+q.push({name: 'foo'}, function (err) {
+    console.log('finished processing foo');
+});
+q.push({name: 'bar'}, function (err) {
+    console.log('finished processing bar');
+});
+
+// add some items to the queue (batch-wise)
+
+q.push([{name: 'baz'},{name: 'bay'},{name: 'bax'}], function (err) {
+    console.log('finished processing bar');
+});
+
+// add some items to the front of the queue
+
+q.unshift({name: 'bar'}, function (err) {
+    console.log('finished processing bar');
+});
+```
+
+---------------------------------------
+
+<a name="cargo" />
+### cargo(worker, [payload])
+
+Creates a cargo object with the specified payload. Tasks added to the
+cargo will be processed altogether (up to the payload limit). If the
+worker is in progress, the task is queued until it is available. Once
+the worker has completed some tasks, each callback of those tasks is called.
+
+__Arguments__
+
+* worker(tasks, callback) - An asynchronous function for processing an array of
+  queued tasks, which must call its callback(err) argument when finished, with 
+  an optional error as an argument.
+* payload - An optional integer for determining how many tasks should be
+  processed per round; if omitted, the default is unlimited.
+
+__Cargo objects__
+
+The cargo object returned by this function has the following properties and
+methods:
+
+* length() - a function returning the number of items waiting to be processed.
+* payload - an integer for determining how many tasks should be
+  process per round. This property can be changed after a cargo is created to
+  alter the payload on-the-fly.
+* push(task, [callback]) - add a new task to the queue, the callback is called
+  once the worker has finished processing the task.
+  instead of a single task, an array of tasks can be submitted. the respective callback is used for every task in the list.
+* saturated - a callback that is called when the queue length hits the concurrency and further tasks will be queued
+* empty - a callback that is called when the last item from the queue is given to a worker
+* drain - a callback that is called when the last item from the queue has returned from the worker
+
+__Example__
+
+```js
+// create a cargo object with payload 2
+
+var cargo = async.cargo(function (tasks, callback) {
+    for(var i=0; i<tasks.length; i++){
+      console.log('hello ' + tasks[i].name);
+    }
+    callback();
+}, 2);
+
+
+// add some items
+
+cargo.push({name: 'foo'}, function (err) {
+    console.log('finished processing foo');
+});
+cargo.push({name: 'bar'}, function (err) {
+    console.log('finished processing bar');
+});
+cargo.push({name: 'baz'}, function (err) {
+    console.log('finished processing baz');
+});
+```
+
+---------------------------------------
+
+<a name="auto" />
+### auto(tasks, [callback])
+
+Determines the best order for running functions based on their requirements.
+Each function can optionally depend on other functions being completed first,
+and each function is run as soon as its requirements are satisfied. If any of
+the functions pass an error to their callback, that function will not complete
+(so any other functions depending on it will not run) and the main callback
+will be called immediately with the error. Functions also receive an object
+containing the results of functions which have completed so far.
+
+Note, all functions are called with a results object as a second argument, 
+so it is unsafe to pass functions in the tasks object which cannot handle the
+extra argument. For example, this snippet of code:
+
+```js
+async.auto({
+  readData: async.apply(fs.readFile, 'data.txt', 'utf-8')
+}, callback);
+```
+
+will have the effect of calling readFile with the results object as the last
+argument, which will fail:
+
+```js
+fs.readFile('data.txt', 'utf-8', cb, {});
+```
+
+Instead, wrap the call to readFile in a function which does not forward the 
+results object:
+
+```js
+async.auto({
+  readData: function(cb, results){
+    fs.readFile('data.txt', 'utf-8', cb);
+  }
+}, callback);
+```
+
+__Arguments__
+
+* tasks - An object literal containing named functions or an array of
+  requirements, with the function itself the last item in the array. The key
+  used for each function or array is used when specifying requirements. The 
+  function receives two arguments: (1) a callback(err, result) which must be 
+  called when finished, passing an error (which can be null) and the result of 
+  the function's execution, and (2) a results object, containing the results of
+  the previously executed functions.
+* callback(err, results) - An optional callback which is called when all the
+  tasks have been completed. The callback will receive an error as an argument
+  if any tasks pass an error to their callback. Results will always be passed
+	but if an error occurred, no other tasks will be performed, and the results
+	object will only contain partial results.
+  
+
+__Example__
+
+```js
+async.auto({
+    get_data: function(callback){
+        // async code to get some data
+    },
+    make_folder: function(callback){
+        // async code to create a directory to store a file in
+        // this is run at the same time as getting the data
+    },
+    write_file: ['get_data', 'make_folder', function(callback){
+        // once there is some data and the directory exists,
+        // write the data to a file in the directory
+        callback(null, filename);
+    }],
+    email_link: ['write_file', function(callback, results){
+        // once the file is written let's email a link to it...
+        // results.write_file contains the filename returned by write_file.
+    }]
+});
+```
+
+This is a fairly trivial example, but to do this using the basic parallel and
+series functions would look like this:
+
+```js
+async.parallel([
+    function(callback){
+        // async code to get some data
+    },
+    function(callback){
+        // async code to create a directory to store a file in
+        // this is run at the same time as getting the data
+    }
+],
+function(err, results){
+    async.series([
+        function(callback){
+            // once there is some data and the directory exists,
+            // write the data to a file in the directory
+        },
+        function(callback){
+            // once the file is written let's email a link to it...
+        }
+    ]);
+});
+```
+
+For a complicated series of async tasks using the auto function makes adding
+new tasks much easier and makes the code more readable.
+
+
+---------------------------------------
+
+<a name="iterator" />
+### iterator(tasks)
+
+Creates an iterator function which calls the next function in the array,
+returning a continuation to call the next one after that. It's also possible to
+'peek' the next iterator by doing iterator.next().
+
+This function is used internally by the async module but can be useful when
+you want to manually control the flow of functions in series.
+
+__Arguments__
+
+* tasks - An array of functions to run.
+
+__Example__
+
+```js
+var iterator = async.iterator([
+    function(){ sys.p('one'); },
+    function(){ sys.p('two'); },
+    function(){ sys.p('three'); }
+]);
+
+node> var iterator2 = iterator();
+'one'
+node> var iterator3 = iterator2();
+'two'
+node> iterator3();
+'three'
+node> var nextfn = iterator2.next();
+node> nextfn();
+'three'
+```
+
+---------------------------------------
+
+<a name="apply" />
+### apply(function, arguments..)
+
+Creates a continuation function with some arguments already applied, a useful
+shorthand when combined with other control flow functions. Any arguments
+passed to the returned function are added to the arguments originally passed
+to apply.
+
+__Arguments__
+
+* function - The function you want to eventually apply all arguments to.
+* arguments... - Any number of arguments to automatically apply when the
+  continuation is called.
+
+__Example__
+
+```js
+// using apply
+
+async.parallel([
+    async.apply(fs.writeFile, 'testfile1', 'test1'),
+    async.apply(fs.writeFile, 'testfile2', 'test2'),
+]);
+
+
+// the same process without using apply
+
+async.parallel([
+    function(callback){
+        fs.writeFile('testfile1', 'test1', callback);
+    },
+    function(callback){
+        fs.writeFile('testfile2', 'test2', callback);
+    }
+]);
+```
+
+It's possible to pass any number of additional arguments when calling the
+continuation:
+
+```js
+node> var fn = async.apply(sys.puts, 'one');
+node> fn('two', 'three');
+one
+two
+three
+```
+
+---------------------------------------
+
+<a name="nextTick" />
+### nextTick(callback)
+
+Calls the callback on a later loop around the event loop. In node.js this just
+calls process.nextTick, in the browser it falls back to setImmediate(callback)
+if available, otherwise setTimeout(callback, 0), which means other higher priority
+events may precede the execution of the callback.
+
+This is used internally for browser-compatibility purposes.
+
+__Arguments__
+
+* callback - The function to call on a later loop around the event loop.
+
+__Example__
+
+```js
+var call_order = [];
+async.nextTick(function(){
+    call_order.push('two');
+    // call_order now equals ['one','two']
+});
+call_order.push('one')
+```
+
+<a name="times" />
+### times(n, callback)
+
+Calls the callback n times and accumulates results in the same manner
+you would use with async.map.
+
+__Arguments__
+
+* n - The number of times to run the function.
+* callback - The function to call n times.
+
+__Example__
+
+```js
+// Pretend this is some complicated async factory
+var createUser = function(id, callback) {
+  callback(null, {
+    id: 'user' + id
+  })
+}
+// generate 5 users
+async.times(5, function(n, next){
+    createUser(n, function(err, user) {
+      next(err, user)
+    })
+}, function(err, users) {
+  // we should now have 5 users
+});
+```
+
+<a name="timesSeries" />
+### timesSeries(n, callback)
+
+The same as times only the iterator is applied to each item in the array in
+series. The next iterator is only called once the current one has completed
+processing. The results array will be in the same order as the original.
+
+
+## Utils
+
+<a name="memoize" />
+### memoize(fn, [hasher])
+
+Caches the results of an async function. When creating a hash to store function
+results against, the callback is omitted from the hash and an optional hash
+function can be used.
+
+The cache of results is exposed as the `memo` property of the function returned
+by `memoize`.
+
+__Arguments__
+
+* fn - the function you to proxy and cache results from.
+* hasher - an optional function for generating a custom hash for storing
+  results, it has all the arguments applied to it apart from the callback, and
+  must be synchronous.
+
+__Example__
+
+```js
+var slow_fn = function (name, callback) {
+    // do something
+    callback(null, result);
+};
+var fn = async.memoize(slow_fn);
+
+// fn can now be used as if it were slow_fn
+fn('some name', function () {
+    // callback
+});
+```
+
+<a name="unmemoize" />
+### unmemoize(fn)
+
+Undoes a memoized function, reverting it to the original, unmemoized
+form. Comes handy in tests.
+
+__Arguments__
+
+* fn - the memoized function
+
+<a name="log" />
+### log(function, arguments)
+
+Logs the result of an async function to the console. Only works in node.js or
+in browsers that support console.log and console.error (such as FF and Chrome).
+If multiple arguments are returned from the async function, console.log is
+called on each argument in order.
+
+__Arguments__
+
+* function - The function you want to eventually apply all arguments to.
+* arguments... - Any number of arguments to apply to the function.
+
+__Example__
+
+```js
+var hello = function(name, callback){
+    setTimeout(function(){
+        callback(null, 'hello ' + name);
+    }, 1000);
+};
+```
+```js
+node> async.log(hello, 'world');
+'hello world'
+```
+
+---------------------------------------
+
+<a name="dir" />
+### dir(function, arguments)
+
+Logs the result of an async function to the console using console.dir to
+display the properties of the resulting object. Only works in node.js or
+in browsers that support console.dir and console.error (such as FF and Chrome).
+If multiple arguments are returned from the async function, console.dir is
+called on each argument in order.
+
+__Arguments__
+
+* function - The function you want to eventually apply all arguments to.
+* arguments... - Any number of arguments to apply to the function.
+
+__Example__
+
+```js
+var hello = function(name, callback){
+    setTimeout(function(){
+        callback(null, {hello: name});
+    }, 1000);
+};
+```
+```js
+node> async.dir(hello, 'world');
+{hello: 'world'}
+```
+
+---------------------------------------
+
+<a name="noConflict" />
+### noConflict()
+
+Changes the value of async back to its original value, returning a reference to the
+async object.

--- a/src/main/resources/static/bower/async/component.json
+++ b/src/main/resources/static/bower/async/component.json
@@ -1,0 +1,11 @@
+{
+  "name": "async",
+  "repo": "caolan/async",
+  "description": "Higher-order functions and common patterns for asynchronous code",
+  "version": "0.1.23",
+  "keywords": [],
+  "dependencies": {},
+  "development": {},
+  "main": "lib/async.js",
+  "scripts": [ "lib/async.js" ]
+}

--- a/src/main/resources/static/bower/async/deps/nodeunit.css
+++ b/src/main/resources/static/bower/async/deps/nodeunit.css
@@ -1,0 +1,70 @@
+/*!
+ * Styles taken from qunit.css
+ */
+
+h1#nodeunit-header, h1.nodeunit-header {
+    padding: 15px;
+    font-size: large;
+    background-color: #06b;
+    color: white;
+    font-family: 'trebuchet ms', verdana, arial;
+    margin: 0;
+}
+
+h1#nodeunit-header a {
+    color: white;
+}
+
+h2#nodeunit-banner {
+    height: 2em;
+    border-bottom: 1px solid white;
+    background-color: #eee;
+    margin: 0;
+    font-family: 'trebuchet ms', verdana, arial;
+}
+h2#nodeunit-banner.pass {
+    background-color: green;
+}
+h2#nodeunit-banner.fail {
+    background-color: red;
+}
+
+h2#nodeunit-userAgent, h2.nodeunit-userAgent {
+    padding: 10px;
+    background-color: #eee;
+    color: black;
+    margin: 0;
+    font-size: small;
+    font-weight: normal;
+    font-family: 'trebuchet ms', verdana, arial;
+    font-size: 10pt;
+}
+
+div#nodeunit-testrunner-toolbar {
+    background: #eee;
+    border-top: 1px solid black;
+    padding: 10px;
+    font-family: 'trebuchet ms', verdana, arial;
+    margin: 0;
+    font-size: 10pt;
+}
+
+ol#nodeunit-tests {
+    font-family: 'trebuchet ms', verdana, arial;
+    font-size: 10pt;
+}
+ol#nodeunit-tests li strong {
+    cursor:pointer;
+}
+ol#nodeunit-tests .pass {
+    color: green;
+} 
+ol#nodeunit-tests .fail {
+    color: red;
+} 
+
+p#nodeunit-testresult {
+    margin-left: 1em;
+    font-size: 10pt;
+    font-family: 'trebuchet ms', verdana, arial;
+}

--- a/src/main/resources/static/bower/async/deps/nodeunit.js
+++ b/src/main/resources/static/bower/async/deps/nodeunit.js
@@ -1,0 +1,1966 @@
+/*!
+ * Nodeunit
+ * https://github.com/caolan/nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * json2.js
+ * http://www.JSON.org/json2.js
+ * Public Domain.
+ * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+ */
+nodeunit = (function(){
+/*
+    http://www.JSON.org/json2.js
+    2010-11-17
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    See http://www.JSON.org/js.html
+
+
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+
+
+    This file creates a global JSON object containing two methods: stringify
+    and parse.
+
+        JSON.stringify(value, replacer, space)
+            value       any JavaScript value, usually an object or array.
+
+            replacer    an optional parameter that determines how object
+                        values are stringified for objects. It can be a
+                        function or an array of strings.
+
+            space       an optional parameter that specifies the indentation
+                        of nested structures. If it is omitted, the text will
+                        be packed without extra whitespace. If it is a number,
+                        it will specify the number of spaces to indent at each
+                        level. If it is a string (such as '\t' or '&nbsp;'),
+                        it contains the characters used to indent at each level.
+
+            This method produces a JSON text from a JavaScript value.
+
+            When an object value is found, if the object contains a toJSON
+            method, its toJSON method will be called and the result will be
+            stringified. A toJSON method does not serialize: it returns the
+            value represented by the name/value pair that should be serialized,
+            or undefined if nothing should be serialized. The toJSON method
+            will be passed the key associated with the value, and this will be
+            bound to the value
+
+            For example, this would serialize Dates as ISO strings.
+
+                Date.prototype.toJSON = function (key) {
+                    function f(n) {
+                        // Format integers to have at least two digits.
+                        return n < 10 ? '0' + n : n;
+                    }
+
+                    return this.getUTCFullYear()   + '-' +
+                         f(this.getUTCMonth() + 1) + '-' +
+                         f(this.getUTCDate())      + 'T' +
+                         f(this.getUTCHours())     + ':' +
+                         f(this.getUTCMinutes())   + ':' +
+                         f(this.getUTCSeconds())   + 'Z';
+                };
+
+            You can provide an optional replacer method. It will be passed the
+            key and value of each member, with this bound to the containing
+            object. The value that is returned from your method will be
+            serialized. If your method returns undefined, then the member will
+            be excluded from the serialization.
+
+            If the replacer parameter is an array of strings, then it will be
+            used to select the members to be serialized. It filters the results
+            such that only members with keys listed in the replacer array are
+            stringified.
+
+            Values that do not have JSON representations, such as undefined or
+            functions, will not be serialized. Such values in objects will be
+            dropped; in arrays they will be replaced with null. You can use
+            a replacer function to replace those with JSON values.
+            JSON.stringify(undefined) returns undefined.
+
+            The optional space parameter produces a stringification of the
+            value that is filled with line breaks and indentation to make it
+            easier to read.
+
+            If the space parameter is a non-empty string, then that string will
+            be used for indentation. If the space parameter is a number, then
+            the indentation will be that many spaces.
+
+            Example:
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}]);
+            // text is '["e",{"pluribus":"unum"}]'
+
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}], null, '\t');
+            // text is '[\n\t"e",\n\t{\n\t\t"pluribus": "unum"\n\t}\n]'
+
+            text = JSON.stringify([new Date()], function (key, value) {
+                return this[key] instanceof Date ?
+                    'Date(' + this[key] + ')' : value;
+            });
+            // text is '["Date(---current time---)"]'
+
+
+        JSON.parse(text, reviver)
+            This method parses a JSON text to produce an object or array.
+            It can throw a SyntaxError exception.
+
+            The optional reviver parameter is a function that can filter and
+            transform the results. It receives each of the keys and values,
+            and its return value is used instead of the original value.
+            If it returns what it received, then the structure is not modified.
+            If it returns undefined then the member is deleted.
+
+            Example:
+
+            // Parse the text. Values that look like ISO date strings will
+            // be converted to Date objects.
+
+            myData = JSON.parse(text, function (key, value) {
+                var a;
+                if (typeof value === 'string') {
+                    a =
+/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                    if (a) {
+                        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                            +a[5], +a[6]));
+                    }
+                }
+                return value;
+            });
+
+            myData = JSON.parse('["Date(09/09/2001)"]', function (key, value) {
+                var d;
+                if (typeof value === 'string' &&
+                        value.slice(0, 5) === 'Date(' &&
+                        value.slice(-1) === ')') {
+                    d = new Date(value.slice(5, -1));
+                    if (d) {
+                        return d;
+                    }
+                }
+                return value;
+            });
+
+
+    This is a reference implementation. You are free to copy, modify, or
+    redistribute.
+*/
+
+/*jslint evil: true, strict: false, regexp: false */
+
+/*members "", "\b", "\t", "\n", "\f", "\r", "\"", JSON, "\\", apply,
+    call, charCodeAt, getUTCDate, getUTCFullYear, getUTCHours,
+    getUTCMinutes, getUTCMonth, getUTCSeconds, hasOwnProperty, join,
+    lastIndex, length, parse, prototype, push, replace, slice, stringify,
+    test, toJSON, toString, valueOf
+*/
+
+
+// Create a JSON object only if one does not already exist. We create the
+// methods in a closure to avoid creating global variables.
+
+if (!this.JSON) {
+    this.JSON = {};
+}
+
+(function () {
+    "use strict";
+
+    function f(n) {
+        // Format integers to have at least two digits.
+        return n < 10 ? '0' + n : n;
+    }
+
+    if (typeof Date.prototype.toJSON !== 'function') {
+
+        Date.prototype.toJSON = function (key) {
+
+            return isFinite(this.valueOf()) ?
+                   this.getUTCFullYear()   + '-' +
+                 f(this.getUTCMonth() + 1) + '-' +
+                 f(this.getUTCDate())      + 'T' +
+                 f(this.getUTCHours())     + ':' +
+                 f(this.getUTCMinutes())   + ':' +
+                 f(this.getUTCSeconds())   + 'Z' : null;
+        };
+
+        String.prototype.toJSON =
+        Number.prototype.toJSON =
+        Boolean.prototype.toJSON = function (key) {
+            return this.valueOf();
+        };
+    }
+
+    var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        gap,
+        indent,
+        meta = {    // table of character substitutions
+            '\b': '\\b',
+            '\t': '\\t',
+            '\n': '\\n',
+            '\f': '\\f',
+            '\r': '\\r',
+            '"' : '\\"',
+            '\\': '\\\\'
+        },
+        rep;
+
+
+    function quote(string) {
+
+// If the string contains no control characters, no quote characters, and no
+// backslash characters, then we can safely slap some quotes around it.
+// Otherwise we must also replace the offending characters with safe escape
+// sequences.
+
+        escapable.lastIndex = 0;
+        return escapable.test(string) ?
+            '"' + string.replace(escapable, function (a) {
+                var c = meta[a];
+                return typeof c === 'string' ? c :
+                    '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+            }) + '"' :
+            '"' + string + '"';
+    }
+
+
+    function str(key, holder) {
+
+// Produce a string from holder[key].
+
+        var i,          // The loop counter.
+            k,          // The member key.
+            v,          // The member value.
+            length,
+            mind = gap,
+            partial,
+            value = holder[key];
+
+// If the value has a toJSON method, call it to obtain a replacement value.
+
+        if (value && typeof value === 'object' &&
+                typeof value.toJSON === 'function') {
+            value = value.toJSON(key);
+        }
+
+// If we were called with a replacer function, then call the replacer to
+// obtain a replacement value.
+
+        if (typeof rep === 'function') {
+            value = rep.call(holder, key, value);
+        }
+
+// What happens next depends on the value's type.
+
+        switch (typeof value) {
+        case 'string':
+            return quote(value);
+
+        case 'number':
+
+// JSON numbers must be finite. Encode non-finite numbers as null.
+
+            return isFinite(value) ? String(value) : 'null';
+
+        case 'boolean':
+        case 'null':
+
+// If the value is a boolean or null, convert it to a string. Note:
+// typeof null does not produce 'null'. The case is included here in
+// the remote chance that this gets fixed someday.
+
+            return String(value);
+
+// If the type is 'object', we might be dealing with an object or an array or
+// null.
+
+        case 'object':
+
+// Due to a specification blunder in ECMAScript, typeof null is 'object',
+// so watch out for that case.
+
+            if (!value) {
+                return 'null';
+            }
+
+// Make an array to hold the partial results of stringifying this object value.
+
+            gap += indent;
+            partial = [];
+
+// Is the value an array?
+
+            if (Object.prototype.toString.apply(value) === '[object Array]') {
+
+// The value is an array. Stringify every element. Use null as a placeholder
+// for non-JSON values.
+
+                length = value.length;
+                for (i = 0; i < length; i += 1) {
+                    partial[i] = str(i, value) || 'null';
+                }
+
+// Join all of the elements together, separated with commas, and wrap them in
+// brackets.
+
+                v = partial.length === 0 ? '[]' :
+                    gap ? '[\n' + gap +
+                            partial.join(',\n' + gap) + '\n' +
+                                mind + ']' :
+                          '[' + partial.join(',') + ']';
+                gap = mind;
+                return v;
+            }
+
+// If the replacer is an array, use it to select the members to be stringified.
+
+            if (rep && typeof rep === 'object') {
+                length = rep.length;
+                for (i = 0; i < length; i += 1) {
+                    k = rep[i];
+                    if (typeof k === 'string') {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
+                    }
+                }
+            } else {
+
+// Otherwise, iterate through all of the keys in the object.
+
+                for (k in value) {
+                    if (Object.hasOwnProperty.call(value, k)) {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
+                    }
+                }
+            }
+
+// Join all of the member texts together, separated with commas,
+// and wrap them in braces.
+
+            v = partial.length === 0 ? '{}' :
+                gap ? '{\n' + gap + partial.join(',\n' + gap) + '\n' +
+                        mind + '}' : '{' + partial.join(',') + '}';
+            gap = mind;
+            return v;
+        }
+    }
+
+// If the JSON object does not yet have a stringify method, give it one.
+
+    if (typeof JSON.stringify !== 'function') {
+        JSON.stringify = function (value, replacer, space) {
+
+// The stringify method takes a value and an optional replacer, and an optional
+// space parameter, and returns a JSON text. The replacer can be a function
+// that can replace values, or an array of strings that will select the keys.
+// A default replacer method can be provided. Use of the space parameter can
+// produce text that is more easily readable.
+
+            var i;
+            gap = '';
+            indent = '';
+
+// If the space parameter is a number, make an indent string containing that
+// many spaces.
+
+            if (typeof space === 'number') {
+                for (i = 0; i < space; i += 1) {
+                    indent += ' ';
+                }
+
+// If the space parameter is a string, it will be used as the indent string.
+
+            } else if (typeof space === 'string') {
+                indent = space;
+            }
+
+// If there is a replacer, it must be a function or an array.
+// Otherwise, throw an error.
+
+            rep = replacer;
+            if (replacer && typeof replacer !== 'function' &&
+                    (typeof replacer !== 'object' ||
+                     typeof replacer.length !== 'number')) {
+                throw new Error('JSON.stringify');
+            }
+
+// Make a fake root object containing our value under the key of ''.
+// Return the result of stringifying the value.
+
+            return str('', {'': value});
+        };
+    }
+
+
+// If the JSON object does not yet have a parse method, give it one.
+
+    if (typeof JSON.parse !== 'function') {
+        JSON.parse = function (text, reviver) {
+
+// The parse method takes a text and an optional reviver function, and returns
+// a JavaScript value if the text is a valid JSON text.
+
+            var j;
+
+            function walk(holder, key) {
+
+// The walk method is used to recursively walk the resulting structure so
+// that modifications can be made.
+
+                var k, v, value = holder[key];
+                if (value && typeof value === 'object') {
+                    for (k in value) {
+                        if (Object.hasOwnProperty.call(value, k)) {
+                            v = walk(value, k);
+                            if (v !== undefined) {
+                                value[k] = v;
+                            } else {
+                                delete value[k];
+                            }
+                        }
+                    }
+                }
+                return reviver.call(holder, key, value);
+            }
+
+
+// Parsing happens in four stages. In the first stage, we replace certain
+// Unicode characters with escape sequences. JavaScript handles many characters
+// incorrectly, either silently deleting them, or treating them as line endings.
+
+            text = String(text);
+            cx.lastIndex = 0;
+            if (cx.test(text)) {
+                text = text.replace(cx, function (a) {
+                    return '\\u' +
+                        ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+                });
+            }
+
+// In the second stage, we run the text against regular expressions that look
+// for non-JSON patterns. We are especially concerned with '()' and 'new'
+// because they can cause invocation, and '=' because it can cause mutation.
+// But just to be safe, we want to reject all unexpected forms.
+
+// We split the second stage into 4 regexp operations in order to work around
+// crippling inefficiencies in IE's and Safari's regexp engines. First we
+// replace the JSON backslash pairs with '@' (a non-JSON character). Second, we
+// replace all simple value tokens with ']' characters. Third, we delete all
+// open brackets that follow a colon or comma or that begin the text. Finally,
+// we look to see that the remaining characters are only whitespace or ']' or
+// ',' or ':' or '{' or '}'. If that is so, then the text is safe for eval.
+
+            if (/^[\],:{}\s]*$/
+.test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@')
+.replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']')
+.replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
+
+// In the third stage we use the eval function to compile the text into a
+// JavaScript structure. The '{' operator is subject to a syntactic ambiguity
+// in JavaScript: it can begin a block or an object literal. We wrap the text
+// in parens to eliminate the ambiguity.
+
+                j = eval('(' + text + ')');
+
+// In the optional fourth stage, we recursively walk the new structure, passing
+// each name/value pair to a reviver function for possible transformation.
+
+                return typeof reviver === 'function' ?
+                    walk({'': j}, '') : j;
+            }
+
+// If the text is not JSON parseable, then a SyntaxError is thrown.
+
+            throw new SyntaxError('JSON.parse');
+        };
+    }
+}());
+var assert = this.assert = {};
+var types = {};
+var core = {};
+var nodeunit = {};
+var reporter = {};
+/*global setTimeout: false, console: false */
+(function () {
+
+    var async = {};
+
+    // global on the server, window in the browser
+    var root = this,
+        previous_async = root.async;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = async;
+    }
+    else {
+        root.async = async;
+    }
+
+    async.noConflict = function () {
+        root.async = previous_async;
+        return async;
+    };
+
+    //// cross-browser compatiblity functions ////
+
+    var _forEach = function (arr, iterator) {
+        if (arr.forEach) {
+            return arr.forEach(iterator);
+        }
+        for (var i = 0; i < arr.length; i += 1) {
+            iterator(arr[i], i, arr);
+        }
+    };
+
+    var _map = function (arr, iterator) {
+        if (arr.map) {
+            return arr.map(iterator);
+        }
+        var results = [];
+        _forEach(arr, function (x, i, a) {
+            results.push(iterator(x, i, a));
+        });
+        return results;
+    };
+
+    var _reduce = function (arr, iterator, memo) {
+        if (arr.reduce) {
+            return arr.reduce(iterator, memo);
+        }
+        _forEach(arr, function (x, i, a) {
+            memo = iterator(memo, x, i, a);
+        });
+        return memo;
+    };
+
+    var _keys = function (obj) {
+        if (Object.keys) {
+            return Object.keys(obj);
+        }
+        var keys = [];
+        for (var k in obj) {
+            if (obj.hasOwnProperty(k)) {
+                keys.push(k);
+            }
+        }
+        return keys;
+    };
+
+    var _indexOf = function (arr, item) {
+        if (arr.indexOf) {
+            return arr.indexOf(item);
+        }
+        for (var i = 0; i < arr.length; i += 1) {
+            if (arr[i] === item) {
+                return i;
+            }
+        }
+        return -1;
+    };
+
+    //// exported async module functions ////
+
+    //// nextTick implementation with browser-compatible fallback ////
+    async.nextTick = function (fn) {
+        if (typeof process === 'undefined' || !(process.nextTick)) {
+            setTimeout(fn, 0);
+        }
+        else {
+            process.nextTick(fn);
+        }
+    };
+
+    async.forEach = function (arr, iterator, callback) {
+        if (!arr.length) {
+            return callback();
+        }
+        var completed = 0;
+        _forEach(arr, function (x) {
+            iterator(x, function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed === arr.length) {
+                        callback();
+                    }
+                }
+            });
+        });
+    };
+
+    async.forEachSeries = function (arr, iterator, callback) {
+        if (!arr.length) {
+            return callback();
+        }
+        var completed = 0;
+        var iterate = function () {
+            iterator(arr[completed], function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed === arr.length) {
+                        callback();
+                    }
+                    else {
+                        iterate();
+                    }
+                }
+            });
+        };
+        iterate();
+    };
+
+
+    var doParallel = function (fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [async.forEach].concat(args));
+        };
+    };
+    var doSeries = function (fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [async.forEachSeries].concat(args));
+        };
+    };
+
+
+    var _asyncMap = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (err, v) {
+                results[x.index] = v;
+                callback(err);
+            });
+        }, function (err) {
+            callback(err, results);
+        });
+    };
+    async.map = doParallel(_asyncMap);
+    async.mapSeries = doSeries(_asyncMap);
+
+
+    // reduce only has a series version, as doing reduce in parallel won't
+    // work in many situations.
+    async.reduce = function (arr, memo, iterator, callback) {
+        async.forEachSeries(arr, function (x, callback) {
+            iterator(memo, x, function (err, v) {
+                memo = v;
+                callback(err);
+            });
+        }, function (err) {
+            callback(err, memo);
+        });
+    };
+    // inject alias
+    async.inject = async.reduce;
+    // foldl alias
+    async.foldl = async.reduce;
+
+    async.reduceRight = function (arr, memo, iterator, callback) {
+        var reversed = _map(arr, function (x) {
+            return x;
+        }).reverse();
+        async.reduce(reversed, memo, iterator, callback);
+    };
+    // foldr alias
+    async.foldr = async.reduceRight;
+
+    var _filter = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (v) {
+                if (v) {
+                    results.push(x);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(_map(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), function (x) {
+                return x.value;
+            }));
+        });
+    };
+    async.filter = doParallel(_filter);
+    async.filterSeries = doSeries(_filter);
+    // select alias
+    async.select = async.filter;
+    async.selectSeries = async.filterSeries;
+
+    var _reject = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (v) {
+                if (!v) {
+                    results.push(x);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(_map(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), function (x) {
+                return x.value;
+            }));
+        });
+    };
+    async.reject = doParallel(_reject);
+    async.rejectSeries = doSeries(_reject);
+
+    var _detect = function (eachfn, arr, iterator, main_callback) {
+        eachfn(arr, function (x, callback) {
+            iterator(x, function (result) {
+                if (result) {
+                    main_callback(x);
+                }
+                else {
+                    callback();
+                }
+            });
+        }, function (err) {
+            main_callback();
+        });
+    };
+    async.detect = doParallel(_detect);
+    async.detectSeries = doSeries(_detect);
+
+    async.some = function (arr, iterator, main_callback) {
+        async.forEach(arr, function (x, callback) {
+            iterator(x, function (v) {
+                if (v) {
+                    main_callback(true);
+                    main_callback = function () {};
+                }
+                callback();
+            });
+        }, function (err) {
+            main_callback(false);
+        });
+    };
+    // any alias
+    async.any = async.some;
+
+    async.every = function (arr, iterator, main_callback) {
+        async.forEach(arr, function (x, callback) {
+            iterator(x, function (v) {
+                if (!v) {
+                    main_callback(false);
+                    main_callback = function () {};
+                }
+                callback();
+            });
+        }, function (err) {
+            main_callback(true);
+        });
+    };
+    // all alias
+    async.all = async.every;
+
+    async.sortBy = function (arr, iterator, callback) {
+        async.map(arr, function (x, callback) {
+            iterator(x, function (err, criteria) {
+                if (err) {
+                    callback(err);
+                }
+                else {
+                    callback(null, {value: x, criteria: criteria});
+                }
+            });
+        }, function (err, results) {
+            if (err) {
+                return callback(err);
+            }
+            else {
+                var fn = function (left, right) {
+                    var a = left.criteria, b = right.criteria;
+                    return a < b ? -1 : a > b ? 1 : 0;
+                };
+                callback(null, _map(results.sort(fn), function (x) {
+                    return x.value;
+                }));
+            }
+        });
+    };
+
+    async.auto = function (tasks, callback) {
+        callback = callback || function () {};
+        var keys = _keys(tasks);
+        if (!keys.length) {
+            return callback(null);
+        }
+
+        var completed = [];
+
+        var listeners = [];
+        var addListener = function (fn) {
+            listeners.unshift(fn);
+        };
+        var removeListener = function (fn) {
+            for (var i = 0; i < listeners.length; i += 1) {
+                if (listeners[i] === fn) {
+                    listeners.splice(i, 1);
+                    return;
+                }
+            }
+        };
+        var taskComplete = function () {
+            _forEach(listeners, function (fn) {
+                fn();
+            });
+        };
+
+        addListener(function () {
+            if (completed.length === keys.length) {
+                callback(null);
+            }
+        });
+
+        _forEach(keys, function (k) {
+            var task = (tasks[k] instanceof Function) ? [tasks[k]]: tasks[k];
+            var taskCallback = function (err) {
+                if (err) {
+                    callback(err);
+                    // stop subsequent errors hitting callback multiple times
+                    callback = function () {};
+                }
+                else {
+                    completed.push(k);
+                    taskComplete();
+                }
+            };
+            var requires = task.slice(0, Math.abs(task.length - 1)) || [];
+            var ready = function () {
+                return _reduce(requires, function (a, x) {
+                    return (a && _indexOf(completed, x) !== -1);
+                }, true);
+            };
+            if (ready()) {
+                task[task.length - 1](taskCallback);
+            }
+            else {
+                var listener = function () {
+                    if (ready()) {
+                        removeListener(listener);
+                        task[task.length - 1](taskCallback);
+                    }
+                };
+                addListener(listener);
+            }
+        });
+    };
+
+    async.waterfall = function (tasks, callback) {
+        if (!tasks.length) {
+            return callback();
+        }
+        callback = callback || function () {};
+        var wrapIterator = function (iterator) {
+            return function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    var next = iterator.next();
+                    if (next) {
+                        args.push(wrapIterator(next));
+                    }
+                    else {
+                        args.push(callback);
+                    }
+                    async.nextTick(function () {
+                        iterator.apply(null, args);
+                    });
+                }
+            };
+        };
+        wrapIterator(async.iterator(tasks))();
+    };
+
+    async.parallel = function (tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor === Array) {
+            async.map(tasks, function (fn, callback) {
+                if (fn) {
+                    fn(function (err) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        if (args.length <= 1) {
+                            args = args[0];
+                        }
+                        callback.call(null, err, args || null);
+                    });
+                }
+            }, callback);
+        }
+        else {
+            var results = {};
+            async.forEach(_keys(tasks), function (k, callback) {
+                tasks[k](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    results[k] = args;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
+    };
+
+    async.series = function (tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor === Array) {
+            async.mapSeries(tasks, function (fn, callback) {
+                if (fn) {
+                    fn(function (err) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        if (args.length <= 1) {
+                            args = args[0];
+                        }
+                        callback.call(null, err, args || null);
+                    });
+                }
+            }, callback);
+        }
+        else {
+            var results = {};
+            async.forEachSeries(_keys(tasks), function (k, callback) {
+                tasks[k](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    results[k] = args;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
+    };
+
+    async.iterator = function (tasks) {
+        var makeCallback = function (index) {
+            var fn = function () {
+                if (tasks.length) {
+                    tasks[index].apply(null, arguments);
+                }
+                return fn.next();
+            };
+            fn.next = function () {
+                return (index < tasks.length - 1) ? makeCallback(index + 1): null;
+            };
+            return fn;
+        };
+        return makeCallback(0);
+    };
+
+    async.apply = function (fn) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return function () {
+            return fn.apply(
+                null, args.concat(Array.prototype.slice.call(arguments))
+            );
+        };
+    };
+
+    var _concat = function (eachfn, arr, fn, callback) {
+        var r = [];
+        eachfn(arr, function (x, cb) {
+            fn(x, function (err, y) {
+                r = r.concat(y || []);
+                cb(err);
+            });
+        }, function (err) {
+            callback(err, r);
+        });
+    };
+    async.concat = doParallel(_concat);
+    async.concatSeries = doSeries(_concat);
+
+    async.whilst = function (test, iterator, callback) {
+        if (test()) {
+            iterator(function (err) {
+                if (err) {
+                    return callback(err);
+                }
+                async.whilst(test, iterator, callback);
+            });
+        }
+        else {
+            callback();
+        }
+    };
+
+    async.until = function (test, iterator, callback) {
+        if (!test()) {
+            iterator(function (err) {
+                if (err) {
+                    return callback(err);
+                }
+                async.until(test, iterator, callback);
+            });
+        }
+        else {
+            callback();
+        }
+    };
+
+    async.queue = function (worker, concurrency) {
+        var workers = 0;
+        var tasks = [];
+        var q = {
+            concurrency: concurrency,
+            push: function (data, callback) {
+                tasks.push({data: data, callback: callback});
+                async.nextTick(q.process);
+            },
+            process: function () {
+                if (workers < q.concurrency && tasks.length) {
+                    var task = tasks.splice(0, 1)[0];
+                    workers += 1;
+                    worker(task.data, function () {
+                        workers -= 1;
+                        if (task.callback) {
+                            task.callback.apply(task, arguments);
+                        }
+                        q.process();
+                    });
+                }
+            },
+            length: function () {
+                return tasks.length;
+            }
+        };
+        return q;
+    };
+
+    var _console_fn = function (name) {
+        return function (fn) {
+            var args = Array.prototype.slice.call(arguments, 1);
+            fn.apply(null, args.concat([function (err) {
+                var args = Array.prototype.slice.call(arguments, 1);
+                if (typeof console !== 'undefined') {
+                    if (err) {
+                        if (console.error) {
+                            console.error(err);
+                        }
+                    }
+                    else if (console[name]) {
+                        _forEach(args, function (x) {
+                            console[name](x);
+                        });
+                    }
+                }
+            }]));
+        };
+    };
+    async.log = _console_fn('log');
+    async.dir = _console_fn('dir');
+    /*async.info = _console_fn('info');
+    async.warn = _console_fn('warn');
+    async.error = _console_fn('error');*/
+
+}());
+(function(exports){
+/**
+ * This file is based on the node.js assert module, but with some small
+ * changes for browser-compatibility
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ */
+
+
+/**
+ * Added for browser compatibility
+ */
+
+var _keys = function(obj){
+    if(Object.keys) return Object.keys(obj);
+    var keys = [];
+    for(var k in obj){
+        if(obj.hasOwnProperty(k)) keys.push(k);
+    }
+    return keys;
+};
+
+
+
+// http://wiki.commonjs.org/wiki/Unit_Testing/1.0
+//
+// THIS IS NOT TESTED NOR LIKELY TO WORK OUTSIDE V8!
+//
+// Originally from narwhal.js (http://narwhaljs.org)
+// Copyright (c) 2009 Thomas Robinson <280north.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var pSlice = Array.prototype.slice;
+
+// 1. The assert module provides functions that throw
+// AssertionError's when particular conditions are not met. The
+// assert module must conform to the following interface.
+
+var assert = exports;
+
+// 2. The AssertionError is defined in assert.
+// new assert.AssertionError({message: message, actual: actual, expected: expected})
+
+assert.AssertionError = function AssertionError (options) {
+  this.name = "AssertionError";
+  this.message = options.message;
+  this.actual = options.actual;
+  this.expected = options.expected;
+  this.operator = options.operator;
+  var stackStartFunction = options.stackStartFunction || fail;
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, stackStartFunction);
+  }
+};
+// code from util.inherits in node
+assert.AssertionError.super_ = Error;
+
+
+// EDITED FOR BROWSER COMPATIBILITY: replaced Object.create call
+// TODO: test what effect this may have
+var ctor = function () { this.constructor = assert.AssertionError; };
+ctor.prototype = Error.prototype;
+assert.AssertionError.prototype = new ctor();
+
+
+assert.AssertionError.prototype.toString = function() {
+  if (this.message) {
+    return [this.name+":", this.message].join(' ');
+  } else {
+    return [ this.name+":"
+           , JSON.stringify(this.expected )
+           , this.operator
+           , JSON.stringify(this.actual)
+           ].join(" ");
+  }
+};
+
+// assert.AssertionError instanceof Error
+
+assert.AssertionError.__proto__ = Error.prototype;
+
+// At present only the three keys mentioned above are used and
+// understood by the spec. Implementations or sub modules can pass
+// other keys to the AssertionError's constructor - they will be
+// ignored.
+
+// 3. All of the following functions must throw an AssertionError
+// when a corresponding condition is not met, with a message that
+// may be undefined if not provided.  All assertion methods provide
+// both the actual and expected values to the assertion error for
+// display purposes.
+
+function fail(actual, expected, message, operator, stackStartFunction) {
+  throw new assert.AssertionError({
+    message: message,
+    actual: actual,
+    expected: expected,
+    operator: operator,
+    stackStartFunction: stackStartFunction
+  });
+}
+
+// EXTENSION! allows for well behaved errors defined elsewhere.
+assert.fail = fail;
+
+// 4. Pure assertion tests whether a value is truthy, as determined
+// by !!guard.
+// assert.ok(guard, message_opt);
+// This statement is equivalent to assert.equal(true, guard,
+// message_opt);. To test strictly for the value true, use
+// assert.strictEqual(true, guard, message_opt);.
+
+assert.ok = function ok(value, message) {
+  if (!!!value) fail(value, true, message, "==", assert.ok);
+};
+
+// 5. The equality assertion tests shallow, coercive equality with
+// ==.
+// assert.equal(actual, expected, message_opt);
+
+assert.equal = function equal(actual, expected, message) {
+  if (actual != expected) fail(actual, expected, message, "==", assert.equal);
+};
+
+// 6. The non-equality assertion tests for whether two objects are not equal
+// with != assert.notEqual(actual, expected, message_opt);
+
+assert.notEqual = function notEqual(actual, expected, message) {
+  if (actual == expected) {
+    fail(actual, expected, message, "!=", assert.notEqual);
+  }
+};
+
+// 7. The equivalence assertion tests a deep equality relation.
+// assert.deepEqual(actual, expected, message_opt);
+
+assert.deepEqual = function deepEqual(actual, expected, message) {
+  if (!_deepEqual(actual, expected)) {
+    fail(actual, expected, message, "deepEqual", assert.deepEqual);
+  }
+};
+
+function _deepEqual(actual, expected) {
+  // 7.1. All identical values are equivalent, as determined by ===.
+  if (actual === expected) {
+    return true;
+  // 7.2. If the expected value is a Date object, the actual value is
+  // equivalent if it is also a Date object that refers to the same time.
+  } else if (actual instanceof Date && expected instanceof Date) {
+    return actual.getTime() === expected.getTime();
+
+  // 7.3. Other pairs that do not both pass typeof value == "object",
+  // equivalence is determined by ==.
+  } else if (typeof actual != 'object' && typeof expected != 'object') {
+    return actual == expected;
+
+  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // determined by having the same number of owned properties (as verified
+  // with Object.prototype.hasOwnProperty.call), the same set of keys
+  // (although not necessarily the same order), equivalent values for every
+  // corresponding key, and an identical "prototype" property. Note: this
+  // accounts for both named and indexed properties on Arrays.
+  } else {
+    return objEquiv(actual, expected);
+  }
+}
+
+function isUndefinedOrNull (value) {
+  return value === null || value === undefined;
+}
+
+function isArguments (object) {
+  return Object.prototype.toString.call(object) == '[object Arguments]';
+}
+
+function objEquiv (a, b) {
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+    return false;
+  // an identical "prototype" property.
+  if (a.prototype !== b.prototype) return false;
+  //~~~I've managed to break Object.keys through screwy arguments passing.
+  //   Converting to array solves the problem.
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = pSlice.call(a);
+    b = pSlice.call(b);
+    return _deepEqual(a, b);
+  }
+  try{
+    var ka = _keys(a),
+      kb = _keys(b),
+      key, i;
+  } catch (e) {//happens when one is a string literal and the other isn't
+    return false;
+  }
+  // having the same number of owned properties (keys incorporates hasOwnProperty)
+  if (ka.length != kb.length)
+    return false;
+  //the same set of keys (although not necessarily the same order),
+  ka.sort();
+  kb.sort();
+  //~~~cheap key test
+  for (i = ka.length - 1; i >= 0; i--) {
+    if (ka[i] != kb[i])
+      return false;
+  }
+  //equivalent values for every corresponding key, and
+  //~~~possibly expensive deep test
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!_deepEqual(a[key], b[key] ))
+       return false;
+  }
+  return true;
+}
+
+// 8. The non-equivalence assertion tests for any deep inequality.
+// assert.notDeepEqual(actual, expected, message_opt);
+
+assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
+  if (_deepEqual(actual, expected)) {
+    fail(actual, expected, message, "notDeepEqual", assert.notDeepEqual);
+  }
+};
+
+// 9. The strict equality assertion tests strict equality, as determined by ===.
+// assert.strictEqual(actual, expected, message_opt);
+
+assert.strictEqual = function strictEqual(actual, expected, message) {
+  if (actual !== expected) {
+    fail(actual, expected, message, "===", assert.strictEqual);
+  }
+};
+
+// 10. The strict non-equality assertion tests for strict inequality, as determined by !==.
+// assert.notStrictEqual(actual, expected, message_opt);
+
+assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
+  if (actual === expected) {
+    fail(actual, expected, message, "!==", assert.notStrictEqual);
+  }
+};
+
+function _throws (shouldThrow, block, err, message) {
+  var exception = null,
+      threw = false,
+      typematters = true;
+
+  message = message || "";
+
+  //handle optional arguments
+  if (arguments.length == 3) {
+    if (typeof(err) == "string") {
+      message = err;
+      typematters = false;
+    }
+  } else if (arguments.length == 2) {
+    typematters = false;
+  }
+
+  try {
+    block();
+  } catch (e) {
+    threw = true;
+    exception = e;
+  }
+
+  if (shouldThrow && !threw) {
+    fail( "Missing expected exception"
+        + (err && err.name ? " ("+err.name+")." : '.')
+        + (message ? " " + message : "")
+        );
+  }
+  if (!shouldThrow && threw && typematters && exception instanceof err) {
+    fail( "Got unwanted exception"
+        + (err && err.name ? " ("+err.name+")." : '.')
+        + (message ? " " + message : "")
+        );
+  }
+  if ((shouldThrow && threw && typematters && !(exception instanceof err)) ||
+      (!shouldThrow && threw)) {
+    throw exception;
+  }
+};
+
+// 11. Expected to throw an error:
+// assert.throws(block, Error_opt, message_opt);
+
+assert.throws = function(block, /*optional*/error, /*optional*/message) {
+  _throws.apply(this, [true].concat(pSlice.call(arguments)));
+};
+
+// EXTENSION! This is annoying to write outside this module.
+assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
+  _throws.apply(this, [false].concat(pSlice.call(arguments)));
+};
+
+assert.ifError = function (err) { if (err) {throw err;}};
+})(assert);
+(function(exports){
+/*!
+ * Nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ * Only code on that line will be removed, its mostly to avoid requiring code
+ * that is node specific
+ */
+
+/**
+ * Module dependencies
+ */
+
+
+
+/**
+ * Creates assertion objects representing the result of an assert call.
+ * Accepts an object or AssertionError as its argument.
+ *
+ * @param {object} obj
+ * @api public
+ */
+
+exports.assertion = function (obj) {
+    return {
+        method: obj.method || '',
+        message: obj.message || (obj.error && obj.error.message) || '',
+        error: obj.error,
+        passed: function () {
+            return !this.error;
+        },
+        failed: function () {
+            return Boolean(this.error);
+        }
+    };
+};
+
+/**
+ * Creates an assertion list object representing a group of assertions.
+ * Accepts an array of assertion objects.
+ *
+ * @param {Array} arr
+ * @param {Number} duration
+ * @api public
+ */
+
+exports.assertionList = function (arr, duration) {
+    var that = arr || [];
+    that.failures = function () {
+        var failures = 0;
+        for (var i=0; i<this.length; i++) {
+            if (this[i].failed()) failures++;
+        }
+        return failures;
+    };
+    that.passes = function () {
+        return that.length - that.failures();
+    };
+    that.duration = duration || 0;
+    return that;
+};
+
+/**
+ * Create a wrapper function for assert module methods. Executes a callback
+ * after the it's complete with an assertion object representing the result.
+ *
+ * @param {Function} callback
+ * @api private
+ */
+
+var assertWrapper = function (callback) {
+    return function (new_method, assert_method, arity) {
+        return function () {
+            var message = arguments[arity-1];
+            var a = exports.assertion({method: new_method, message: message});
+            try {
+                assert[assert_method].apply(null, arguments);
+            }
+            catch (e) {
+                a.error = e;
+            }
+            callback(a);
+        };
+    };
+};
+
+/**
+ * Creates the 'test' object that gets passed to every test function.
+ * Accepts the name of the test function as its first argument, followed by
+ * the start time in ms, the options object and a callback function.
+ *
+ * @param {String} name
+ * @param {Number} start
+ * @param {Object} options
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.test = function (name, start, options, callback) {
+    var expecting;
+    var a_list = [];
+
+    var wrapAssert = assertWrapper(function (a) {
+        a_list.push(a);
+        if (options.log) {
+            async.nextTick(function () {
+                options.log(a);
+            });
+        }
+    });
+
+    var test = {
+        done: function (err) {
+            if (expecting !== undefined && expecting !== a_list.length) {
+                var e = new Error(
+                    'Expected ' + expecting + ' assertions, ' +
+                    a_list.length + ' ran'
+                );
+                var a1 = exports.assertion({method: 'expect', error: e});
+                a_list.push(a1);
+                if (options.log) {
+                    async.nextTick(function () {
+                        options.log(a1);
+                    });
+                }
+            }
+            if (err) {
+                var a2 = exports.assertion({error: err});
+                a_list.push(a2);
+                if (options.log) {
+                    async.nextTick(function () {
+                        options.log(a2);
+                    });
+                }
+            }
+            var end = new Date().getTime();
+            async.nextTick(function () {
+                var assertion_list = exports.assertionList(a_list, end - start);
+                options.testDone(name, assertion_list);
+                callback(null, a_list);
+            });
+        },
+        ok: wrapAssert('ok', 'ok', 2),
+        same: wrapAssert('same', 'deepEqual', 3),
+        equals: wrapAssert('equals', 'equal', 3),
+        expect: function (num) {
+            expecting = num;
+        },
+        _assertion_list: a_list
+    };
+    // add all functions from the assert module
+    for (var k in assert) {
+        if (assert.hasOwnProperty(k)) {
+            test[k] = wrapAssert(k, k, assert[k].length);
+        }
+    }
+    return test;
+};
+
+/**
+ * Ensures an options object has all callbacks, adding empty callback functions
+ * if any are missing.
+ *
+ * @param {Object} opt
+ * @return {Object}
+ * @api public
+ */
+
+exports.options = function (opt) {
+    var optionalCallback = function (name) {
+        opt[name] = opt[name] || function () {};
+    };
+
+    optionalCallback('moduleStart');
+    optionalCallback('moduleDone');
+    optionalCallback('testStart');
+    optionalCallback('testDone');
+    //optionalCallback('log');
+
+    // 'done' callback is not optional.
+
+    return opt;
+};
+})(types);
+(function(exports){
+/*!
+ * Nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ * Only code on that line will be removed, its mostly to avoid requiring code
+ * that is node specific
+ */
+
+/**
+ * Module dependencies
+ */
+
+
+
+/**
+ * Added for browser compatibility
+ */
+
+var _keys = function(obj){
+    if(Object.keys) return Object.keys(obj);
+    var keys = [];
+    for(var k in obj){
+        if(obj.hasOwnProperty(k)) keys.push(k);
+    }
+    return keys;
+};
+
+
+/**
+ * Runs a test function (fn) from a loaded module. After the test function
+ * calls test.done(), the callback is executed with an assertionList as its
+ * second argument.
+ *
+ * @param {String} name
+ * @param {Function} fn
+ * @param {Object} opt
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.runTest = function (name, fn, opt, callback) {
+    var options = types.options(opt);
+
+    options.testStart(name);
+    var start = new Date().getTime();
+    var test = types.test(name, start, options, callback);
+
+    try {
+        fn(test);
+    }
+    catch (e) {
+        test.done(e);
+    }
+};
+
+/**
+ * Takes an object containing test functions or other test suites as properties
+ * and runs each in series. After all tests have completed, the callback is
+ * called with a list of all assertions as the second argument.
+ *
+ * If a name is passed to this function it is prepended to all test and suite
+ * names that run within it.
+ *
+ * @param {String} name
+ * @param {Object} suite
+ * @param {Object} opt
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.runSuite = function (name, suite, opt, callback) {
+    var keys = _keys(suite);
+
+    async.concatSeries(keys, function (k, cb) {
+        var prop = suite[k], _name;
+
+        _name = name ? [].concat(name, k) : [k];
+
+        _name.toString = function () {
+            // fallback for old one
+            return this.join(' - ');
+        };
+
+        if (typeof prop === 'function') {
+            exports.runTest(_name, suite[k], opt, cb);
+        }
+        else {
+            exports.runSuite(_name, suite[k], opt, cb);
+        }
+    }, callback);
+};
+
+/**
+ * Run each exported test function or test suite from a loaded module.
+ *
+ * @param {String} name
+ * @param {Object} mod
+ * @param {Object} opt
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.runModule = function (name, mod, opt, callback) {
+    var options = types.options(opt);
+
+    options.moduleStart(name);
+    var start = new Date().getTime();
+
+    exports.runSuite(null, mod, opt, function (err, a_list) {
+        var end = new Date().getTime();
+        var assertion_list = types.assertionList(a_list, end - start);
+        options.moduleDone(name, assertion_list);
+        callback(null, a_list);
+    });
+};
+
+/**
+ * Treats an object literal as a list of modules keyed by name. Runs each
+ * module and finished with calling 'done'. You can think of this as a browser
+ * safe alternative to runFiles in the nodeunit module.
+ *
+ * @param {Object} modules
+ * @param {Object} opt
+ * @api public
+ */
+
+// TODO: add proper unit tests for this function
+exports.runModules = function (modules, opt) {
+    var all_assertions = [];
+    var options = types.options(opt);
+    var start = new Date().getTime();
+
+    async.concatSeries(_keys(modules), function (k, cb) {
+        exports.runModule(k, modules[k], options, cb);
+    },
+    function (err, all_assertions) {
+        var end = new Date().getTime();
+        options.done(types.assertionList(all_assertions, end - start));
+    });
+};
+
+
+/**
+ * Wraps a test function with setUp and tearDown functions.
+ * Used by testCase.
+ *
+ * @param {Function} setUp
+ * @param {Function} tearDown
+ * @param {Function} fn
+ * @api private
+ */
+
+var wrapTest = function (setUp, tearDown, fn) {
+    return function (test) {
+        var context = {};
+        if (tearDown) {
+            var done = test.done;
+            test.done = function (err) {
+                try {
+                    tearDown.call(context, function (err2) {
+                        if (err && err2) {
+                            test._assertion_list.push(
+                                types.assertion({error: err})
+                            );
+                            return done(err2);
+                        }
+                        done(err || err2);
+                    });
+                }
+                catch (e) {
+                    done(e);
+                }
+            };
+        }
+        if (setUp) {
+            setUp.call(context, function (err) {
+                if (err) {
+                    return test.done(err);
+                }
+                fn.call(context, test);
+            });
+        }
+        else {
+            fn.call(context, test);
+        }
+    }
+};
+
+
+/**
+ * Wraps a group of tests with setUp and tearDown functions.
+ * Used by testCase.
+ *
+ * @param {Function} setUp
+ * @param {Function} tearDown
+ * @param {Object} group
+ * @api private
+ */
+
+var wrapGroup = function (setUp, tearDown, group) {
+    var tests = {};
+    var keys = _keys(group);
+    for (var i=0; i<keys.length; i++) {
+        var k = keys[i];
+        if (typeof group[k] === 'function') {
+            tests[k] = wrapTest(setUp, tearDown, group[k]);
+        }
+        else if (typeof group[k] === 'object') {
+            tests[k] = wrapGroup(setUp, tearDown, group[k]);
+        }
+    }
+    return tests;
+}
+
+
+/**
+ * Utility for wrapping a suite of test functions with setUp and tearDown
+ * functions.
+ *
+ * @param {Object} suite
+ * @return {Object}
+ * @api public
+ */
+
+exports.testCase = function (suite) {
+    var setUp = suite.setUp;
+    var tearDown = suite.tearDown;
+    delete suite.setUp;
+    delete suite.tearDown;
+    return wrapGroup(setUp, tearDown, suite);
+};
+})(core);
+(function(exports){
+/*!
+ * Nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ * Only code on that line will be removed, its mostly to avoid requiring code
+ * that is node specific
+ */
+
+
+/**
+ * NOTE: this test runner is not listed in index.js because it cannot be
+ * used with the command-line tool, only inside the browser.
+ */
+
+
+/**
+ * Reporter info string
+ */
+
+exports.info = "Browser-based test reporter";
+
+
+/**
+ * Run all tests within each module, reporting the results
+ *
+ * @param {Array} files
+ * @api public
+ */
+
+exports.run = function (modules, options) {
+    var start = new Date().getTime();
+
+    function setText(el, txt) {
+        if ('innerText' in el) {
+            el.innerText = txt;
+        }
+        else if ('textContent' in el){
+            el.textContent = txt;
+        }
+    }
+
+    function getOrCreate(tag, id) {
+        var el = document.getElementById(id);
+        if (!el) {
+            el = document.createElement(tag);
+            el.id = id;
+            document.body.appendChild(el);
+        }
+        return el;
+    };
+
+    var header = getOrCreate('h1', 'nodeunit-header');
+    var banner = getOrCreate('h2', 'nodeunit-banner');
+    var userAgent = getOrCreate('h2', 'nodeunit-userAgent');
+    var tests = getOrCreate('ol', 'nodeunit-tests');
+    var result = getOrCreate('p', 'nodeunit-testresult');
+
+    setText(userAgent, navigator.userAgent);
+
+    nodeunit.runModules(modules, {
+        moduleStart: function (name) {
+            /*var mheading = document.createElement('h2');
+            mheading.innerText = name;
+            results.appendChild(mheading);
+            module = document.createElement('ol');
+            results.appendChild(module);*/
+        },
+        testDone: function (name, assertions) {
+            var test = document.createElement('li');
+            var strong = document.createElement('strong');
+            strong.innerHTML = name + ' <b style="color: black;">(' +
+                '<b class="fail">' + assertions.failures() + '</b>, ' +
+                '<b class="pass">' + assertions.passes() + '</b>, ' +
+                assertions.length +
+            ')</b>';
+            test.className = assertions.failures() ? 'fail': 'pass';
+            test.appendChild(strong);
+
+            var aList = document.createElement('ol');
+            aList.style.display = 'none';
+            test.onclick = function () {
+                var d = aList.style.display;
+                aList.style.display = (d == 'none') ? 'block': 'none';
+            };
+            for (var i=0; i<assertions.length; i++) {
+                var li = document.createElement('li');
+                var a = assertions[i];
+                if (a.failed()) {
+                    li.innerHTML = (a.message || a.method || 'no message') +
+                        '<pre>' + (a.error.stack || a.error) + '</pre>';
+                    li.className = 'fail';
+                }
+                else {
+                    li.innerHTML = a.message || a.method || 'no message';
+                    li.className = 'pass';
+                }
+                aList.appendChild(li);
+            }
+            test.appendChild(aList);
+            tests.appendChild(test);
+        },
+        done: function (assertions) {
+            var end = new Date().getTime();
+            var duration = end - start;
+
+            var failures = assertions.failures();
+            banner.className = failures ? 'fail': 'pass';
+
+            result.innerHTML = 'Tests completed in ' + duration +
+                ' milliseconds.<br/><span class="passed">' +
+                assertions.passes() + '</span> assertions of ' +
+                '<span class="all">' + assertions.length + '<span> passed, ' +
+                assertions.failures() + ' failed.';
+        }
+    });
+};
+})(reporter);
+nodeunit = core;
+nodeunit.assert = assert;
+nodeunit.reporter = reporter;
+nodeunit.run = reporter.run;
+return nodeunit; })();

--- a/src/main/resources/static/bower/async/lib/async.js
+++ b/src/main/resources/static/bower/async/lib/async.js
@@ -1,0 +1,958 @@
+/*global setImmediate: false, setTimeout: false, console: false */
+(function () {
+
+    var async = {};
+
+    // global on the server, window in the browser
+    var root, previous_async;
+
+    root = this;
+    if (root != null) {
+      previous_async = root.async;
+    }
+
+    async.noConflict = function () {
+        root.async = previous_async;
+        return async;
+    };
+
+    function only_once(fn) {
+        var called = false;
+        return function() {
+            if (called) throw new Error("Callback was already called.");
+            called = true;
+            fn.apply(root, arguments);
+        }
+    }
+
+    //// cross-browser compatiblity functions ////
+
+    var _each = function (arr, iterator) {
+        if (arr.forEach) {
+            return arr.forEach(iterator);
+        }
+        for (var i = 0; i < arr.length; i += 1) {
+            iterator(arr[i], i, arr);
+        }
+    };
+
+    var _map = function (arr, iterator) {
+        if (arr.map) {
+            return arr.map(iterator);
+        }
+        var results = [];
+        _each(arr, function (x, i, a) {
+            results.push(iterator(x, i, a));
+        });
+        return results;
+    };
+
+    var _reduce = function (arr, iterator, memo) {
+        if (arr.reduce) {
+            return arr.reduce(iterator, memo);
+        }
+        _each(arr, function (x, i, a) {
+            memo = iterator(memo, x, i, a);
+        });
+        return memo;
+    };
+
+    var _keys = function (obj) {
+        if (Object.keys) {
+            return Object.keys(obj);
+        }
+        var keys = [];
+        for (var k in obj) {
+            if (obj.hasOwnProperty(k)) {
+                keys.push(k);
+            }
+        }
+        return keys;
+    };
+
+    //// exported async module functions ////
+
+    //// nextTick implementation with browser-compatible fallback ////
+    if (typeof process === 'undefined' || !(process.nextTick)) {
+        if (typeof setImmediate === 'function') {
+            async.nextTick = function (fn) {
+                // not a direct alias for IE10 compatibility
+                setImmediate(fn);
+            };
+            async.setImmediate = async.nextTick;
+        }
+        else {
+            async.nextTick = function (fn) {
+                setTimeout(fn, 0);
+            };
+            async.setImmediate = async.nextTick;
+        }
+    }
+    else {
+        async.nextTick = process.nextTick;
+        if (typeof setImmediate !== 'undefined') {
+            async.setImmediate = function (fn) {
+              // not a direct alias for IE10 compatibility
+              setImmediate(fn);
+            };
+        }
+        else {
+            async.setImmediate = async.nextTick;
+        }
+    }
+
+    async.each = function (arr, iterator, callback) {
+        callback = callback || function () {};
+        if (!arr.length) {
+            return callback();
+        }
+        var completed = 0;
+        _each(arr, function (x) {
+            iterator(x, only_once(function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed >= arr.length) {
+                        callback(null);
+                    }
+                }
+            }));
+        });
+    };
+    async.forEach = async.each;
+
+    async.eachSeries = function (arr, iterator, callback) {
+        callback = callback || function () {};
+        if (!arr.length) {
+            return callback();
+        }
+        var completed = 0;
+        var iterate = function () {
+            iterator(arr[completed], function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed >= arr.length) {
+                        callback(null);
+                    }
+                    else {
+                        iterate();
+                    }
+                }
+            });
+        };
+        iterate();
+    };
+    async.forEachSeries = async.eachSeries;
+
+    async.eachLimit = function (arr, limit, iterator, callback) {
+        var fn = _eachLimit(limit);
+        fn.apply(null, [arr, iterator, callback]);
+    };
+    async.forEachLimit = async.eachLimit;
+
+    var _eachLimit = function (limit) {
+
+        return function (arr, iterator, callback) {
+            callback = callback || function () {};
+            if (!arr.length || limit <= 0) {
+                return callback();
+            }
+            var completed = 0;
+            var started = 0;
+            var running = 0;
+
+            (function replenish () {
+                if (completed >= arr.length) {
+                    return callback();
+                }
+
+                while (running < limit && started < arr.length) {
+                    started += 1;
+                    running += 1;
+                    iterator(arr[started - 1], function (err) {
+                        if (err) {
+                            callback(err);
+                            callback = function () {};
+                        }
+                        else {
+                            completed += 1;
+                            running -= 1;
+                            if (completed >= arr.length) {
+                                callback();
+                            }
+                            else {
+                                replenish();
+                            }
+                        }
+                    });
+                }
+            })();
+        };
+    };
+
+
+    var doParallel = function (fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [async.each].concat(args));
+        };
+    };
+    var doParallelLimit = function(limit, fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [_eachLimit(limit)].concat(args));
+        };
+    };
+    var doSeries = function (fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [async.eachSeries].concat(args));
+        };
+    };
+
+
+    var _asyncMap = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (err, v) {
+                results[x.index] = v;
+                callback(err);
+            });
+        }, function (err) {
+            callback(err, results);
+        });
+    };
+    async.map = doParallel(_asyncMap);
+    async.mapSeries = doSeries(_asyncMap);
+    async.mapLimit = function (arr, limit, iterator, callback) {
+        return _mapLimit(limit)(arr, iterator, callback);
+    };
+
+    var _mapLimit = function(limit) {
+        return doParallelLimit(limit, _asyncMap);
+    };
+
+    // reduce only has a series version, as doing reduce in parallel won't
+    // work in many situations.
+    async.reduce = function (arr, memo, iterator, callback) {
+        async.eachSeries(arr, function (x, callback) {
+            iterator(memo, x, function (err, v) {
+                memo = v;
+                callback(err);
+            });
+        }, function (err) {
+            callback(err, memo);
+        });
+    };
+    // inject alias
+    async.inject = async.reduce;
+    // foldl alias
+    async.foldl = async.reduce;
+
+    async.reduceRight = function (arr, memo, iterator, callback) {
+        var reversed = _map(arr, function (x) {
+            return x;
+        }).reverse();
+        async.reduce(reversed, memo, iterator, callback);
+    };
+    // foldr alias
+    async.foldr = async.reduceRight;
+
+    var _filter = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (v) {
+                if (v) {
+                    results.push(x);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(_map(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), function (x) {
+                return x.value;
+            }));
+        });
+    };
+    async.filter = doParallel(_filter);
+    async.filterSeries = doSeries(_filter);
+    // select alias
+    async.select = async.filter;
+    async.selectSeries = async.filterSeries;
+
+    var _reject = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (v) {
+                if (!v) {
+                    results.push(x);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(_map(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), function (x) {
+                return x.value;
+            }));
+        });
+    };
+    async.reject = doParallel(_reject);
+    async.rejectSeries = doSeries(_reject);
+
+    var _detect = function (eachfn, arr, iterator, main_callback) {
+        eachfn(arr, function (x, callback) {
+            iterator(x, function (result) {
+                if (result) {
+                    main_callback(x);
+                    main_callback = function () {};
+                }
+                else {
+                    callback();
+                }
+            });
+        }, function (err) {
+            main_callback();
+        });
+    };
+    async.detect = doParallel(_detect);
+    async.detectSeries = doSeries(_detect);
+
+    async.some = function (arr, iterator, main_callback) {
+        async.each(arr, function (x, callback) {
+            iterator(x, function (v) {
+                if (v) {
+                    main_callback(true);
+                    main_callback = function () {};
+                }
+                callback();
+            });
+        }, function (err) {
+            main_callback(false);
+        });
+    };
+    // any alias
+    async.any = async.some;
+
+    async.every = function (arr, iterator, main_callback) {
+        async.each(arr, function (x, callback) {
+            iterator(x, function (v) {
+                if (!v) {
+                    main_callback(false);
+                    main_callback = function () {};
+                }
+                callback();
+            });
+        }, function (err) {
+            main_callback(true);
+        });
+    };
+    // all alias
+    async.all = async.every;
+
+    async.sortBy = function (arr, iterator, callback) {
+        async.map(arr, function (x, callback) {
+            iterator(x, function (err, criteria) {
+                if (err) {
+                    callback(err);
+                }
+                else {
+                    callback(null, {value: x, criteria: criteria});
+                }
+            });
+        }, function (err, results) {
+            if (err) {
+                return callback(err);
+            }
+            else {
+                var fn = function (left, right) {
+                    var a = left.criteria, b = right.criteria;
+                    return a < b ? -1 : a > b ? 1 : 0;
+                };
+                callback(null, _map(results.sort(fn), function (x) {
+                    return x.value;
+                }));
+            }
+        });
+    };
+
+    async.auto = function (tasks, callback) {
+        callback = callback || function () {};
+        var keys = _keys(tasks);
+        if (!keys.length) {
+            return callback(null);
+        }
+
+        var results = {};
+
+        var listeners = [];
+        var addListener = function (fn) {
+            listeners.unshift(fn);
+        };
+        var removeListener = function (fn) {
+            for (var i = 0; i < listeners.length; i += 1) {
+                if (listeners[i] === fn) {
+                    listeners.splice(i, 1);
+                    return;
+                }
+            }
+        };
+        var taskComplete = function () {
+            _each(listeners.slice(0), function (fn) {
+                fn();
+            });
+        };
+
+        addListener(function () {
+            if (_keys(results).length === keys.length) {
+                callback(null, results);
+                callback = function () {};
+            }
+        });
+
+        _each(keys, function (k) {
+            var task = (tasks[k] instanceof Function) ? [tasks[k]]: tasks[k];
+            var taskCallback = function (err) {
+                var args = Array.prototype.slice.call(arguments, 1);
+                if (args.length <= 1) {
+                    args = args[0];
+                }
+                if (err) {
+                    var safeResults = {};
+                    _each(_keys(results), function(rkey) {
+                        safeResults[rkey] = results[rkey];
+                    });
+                    safeResults[k] = args;
+                    callback(err, safeResults);
+                    // stop subsequent errors hitting callback multiple times
+                    callback = function () {};
+                }
+                else {
+                    results[k] = args;
+                    async.setImmediate(taskComplete);
+                }
+            };
+            var requires = task.slice(0, Math.abs(task.length - 1)) || [];
+            var ready = function () {
+                return _reduce(requires, function (a, x) {
+                    return (a && results.hasOwnProperty(x));
+                }, true) && !results.hasOwnProperty(k);
+            };
+            if (ready()) {
+                task[task.length - 1](taskCallback, results);
+            }
+            else {
+                var listener = function () {
+                    if (ready()) {
+                        removeListener(listener);
+                        task[task.length - 1](taskCallback, results);
+                    }
+                };
+                addListener(listener);
+            }
+        });
+    };
+
+    async.waterfall = function (tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor !== Array) {
+          var err = new Error('First argument to waterfall must be an array of functions');
+          return callback(err);
+        }
+        if (!tasks.length) {
+            return callback();
+        }
+        var wrapIterator = function (iterator) {
+            return function (err) {
+                if (err) {
+                    callback.apply(null, arguments);
+                    callback = function () {};
+                }
+                else {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    var next = iterator.next();
+                    if (next) {
+                        args.push(wrapIterator(next));
+                    }
+                    else {
+                        args.push(callback);
+                    }
+                    async.setImmediate(function () {
+                        iterator.apply(null, args);
+                    });
+                }
+            };
+        };
+        wrapIterator(async.iterator(tasks))();
+    };
+
+    var _parallel = function(eachfn, tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor === Array) {
+            eachfn.map(tasks, function (fn, callback) {
+                if (fn) {
+                    fn(function (err) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        if (args.length <= 1) {
+                            args = args[0];
+                        }
+                        callback.call(null, err, args);
+                    });
+                }
+            }, callback);
+        }
+        else {
+            var results = {};
+            eachfn.each(_keys(tasks), function (k, callback) {
+                tasks[k](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    results[k] = args;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
+    };
+
+    async.parallel = function (tasks, callback) {
+        _parallel({ map: async.map, each: async.each }, tasks, callback);
+    };
+
+    async.parallelLimit = function(tasks, limit, callback) {
+        _parallel({ map: _mapLimit(limit), each: _eachLimit(limit) }, tasks, callback);
+    };
+
+    async.series = function (tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor === Array) {
+            async.mapSeries(tasks, function (fn, callback) {
+                if (fn) {
+                    fn(function (err) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        if (args.length <= 1) {
+                            args = args[0];
+                        }
+                        callback.call(null, err, args);
+                    });
+                }
+            }, callback);
+        }
+        else {
+            var results = {};
+            async.eachSeries(_keys(tasks), function (k, callback) {
+                tasks[k](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    results[k] = args;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
+    };
+
+    async.iterator = function (tasks) {
+        var makeCallback = function (index) {
+            var fn = function () {
+                if (tasks.length) {
+                    tasks[index].apply(null, arguments);
+                }
+                return fn.next();
+            };
+            fn.next = function () {
+                return (index < tasks.length - 1) ? makeCallback(index + 1): null;
+            };
+            return fn;
+        };
+        return makeCallback(0);
+    };
+
+    async.apply = function (fn) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return function () {
+            return fn.apply(
+                null, args.concat(Array.prototype.slice.call(arguments))
+            );
+        };
+    };
+
+    var _concat = function (eachfn, arr, fn, callback) {
+        var r = [];
+        eachfn(arr, function (x, cb) {
+            fn(x, function (err, y) {
+                r = r.concat(y || []);
+                cb(err);
+            });
+        }, function (err) {
+            callback(err, r);
+        });
+    };
+    async.concat = doParallel(_concat);
+    async.concatSeries = doSeries(_concat);
+
+    async.whilst = function (test, iterator, callback) {
+        if (test()) {
+            iterator(function (err) {
+                if (err) {
+                    return callback(err);
+                }
+                async.whilst(test, iterator, callback);
+            });
+        }
+        else {
+            callback();
+        }
+    };
+
+    async.doWhilst = function (iterator, test, callback) {
+        iterator(function (err) {
+            if (err) {
+                return callback(err);
+            }
+            if (test()) {
+                async.doWhilst(iterator, test, callback);
+            }
+            else {
+                callback();
+            }
+        });
+    };
+
+    async.until = function (test, iterator, callback) {
+        if (!test()) {
+            iterator(function (err) {
+                if (err) {
+                    return callback(err);
+                }
+                async.until(test, iterator, callback);
+            });
+        }
+        else {
+            callback();
+        }
+    };
+
+    async.doUntil = function (iterator, test, callback) {
+        iterator(function (err) {
+            if (err) {
+                return callback(err);
+            }
+            if (!test()) {
+                async.doUntil(iterator, test, callback);
+            }
+            else {
+                callback();
+            }
+        });
+    };
+
+    async.queue = function (worker, concurrency) {
+        if (concurrency === undefined) {
+            concurrency = 1;
+        }
+        function _insert(q, data, pos, callback) {
+          if(data.constructor !== Array) {
+              data = [data];
+          }
+          _each(data, function(task) {
+              var item = {
+                  data: task,
+                  callback: typeof callback === 'function' ? callback : null
+              };
+
+              if (pos) {
+                q.tasks.unshift(item);
+              } else {
+                q.tasks.push(item);
+              }
+
+              if (q.saturated && q.tasks.length === concurrency) {
+                  q.saturated();
+              }
+              async.setImmediate(q.process);
+          });
+        }
+
+        var workers = 0;
+        var q = {
+            tasks: [],
+            concurrency: concurrency,
+            saturated: null,
+            empty: null,
+            drain: null,
+            push: function (data, callback) {
+              _insert(q, data, false, callback);
+            },
+            unshift: function (data, callback) {
+              _insert(q, data, true, callback);
+            },
+            process: function () {
+                if (workers < q.concurrency && q.tasks.length) {
+                    var task = q.tasks.shift();
+                    if (q.empty && q.tasks.length === 0) {
+                        q.empty();
+                    }
+                    workers += 1;
+                    var next = function () {
+                        workers -= 1;
+                        if (task.callback) {
+                            task.callback.apply(task, arguments);
+                        }
+                        if (q.drain && q.tasks.length + workers === 0) {
+                            q.drain();
+                        }
+                        q.process();
+                    };
+                    var cb = only_once(next);
+                    worker(task.data, cb);
+                }
+            },
+            length: function () {
+                return q.tasks.length;
+            },
+            running: function () {
+                return workers;
+            }
+        };
+        return q;
+    };
+
+    async.cargo = function (worker, payload) {
+        var working     = false,
+            tasks       = [];
+
+        var cargo = {
+            tasks: tasks,
+            payload: payload,
+            saturated: null,
+            empty: null,
+            drain: null,
+            push: function (data, callback) {
+                if(data.constructor !== Array) {
+                    data = [data];
+                }
+                _each(data, function(task) {
+                    tasks.push({
+                        data: task,
+                        callback: typeof callback === 'function' ? callback : null
+                    });
+                    if (cargo.saturated && tasks.length === payload) {
+                        cargo.saturated();
+                    }
+                });
+                async.setImmediate(cargo.process);
+            },
+            process: function process() {
+                if (working) return;
+                if (tasks.length === 0) {
+                    if(cargo.drain) cargo.drain();
+                    return;
+                }
+
+                var ts = typeof payload === 'number'
+                            ? tasks.splice(0, payload)
+                            : tasks.splice(0);
+
+                var ds = _map(ts, function (task) {
+                    return task.data;
+                });
+
+                if(cargo.empty) cargo.empty();
+                working = true;
+                worker(ds, function () {
+                    working = false;
+
+                    var args = arguments;
+                    _each(ts, function (data) {
+                        if (data.callback) {
+                            data.callback.apply(null, args);
+                        }
+                    });
+
+                    process();
+                });
+            },
+            length: function () {
+                return tasks.length;
+            },
+            running: function () {
+                return working;
+            }
+        };
+        return cargo;
+    };
+
+    var _console_fn = function (name) {
+        return function (fn) {
+            var args = Array.prototype.slice.call(arguments, 1);
+            fn.apply(null, args.concat([function (err) {
+                var args = Array.prototype.slice.call(arguments, 1);
+                if (typeof console !== 'undefined') {
+                    if (err) {
+                        if (console.error) {
+                            console.error(err);
+                        }
+                    }
+                    else if (console[name]) {
+                        _each(args, function (x) {
+                            console[name](x);
+                        });
+                    }
+                }
+            }]));
+        };
+    };
+    async.log = _console_fn('log');
+    async.dir = _console_fn('dir');
+    /*async.info = _console_fn('info');
+    async.warn = _console_fn('warn');
+    async.error = _console_fn('error');*/
+
+    async.memoize = function (fn, hasher) {
+        var memo = {};
+        var queues = {};
+        hasher = hasher || function (x) {
+            return x;
+        };
+        var memoized = function () {
+            var args = Array.prototype.slice.call(arguments);
+            var callback = args.pop();
+            var key = hasher.apply(null, args);
+            if (key in memo) {
+                callback.apply(null, memo[key]);
+            }
+            else if (key in queues) {
+                queues[key].push(callback);
+            }
+            else {
+                queues[key] = [callback];
+                fn.apply(null, args.concat([function () {
+                    memo[key] = arguments;
+                    var q = queues[key];
+                    delete queues[key];
+                    for (var i = 0, l = q.length; i < l; i++) {
+                      q[i].apply(null, arguments);
+                    }
+                }]));
+            }
+        };
+        memoized.memo = memo;
+        memoized.unmemoized = fn;
+        return memoized;
+    };
+
+    async.unmemoize = function (fn) {
+      return function () {
+        return (fn.unmemoized || fn).apply(null, arguments);
+      };
+    };
+
+    async.times = function (count, iterator, callback) {
+        var counter = [];
+        for (var i = 0; i < count; i++) {
+            counter.push(i);
+        }
+        return async.map(counter, iterator, callback);
+    };
+
+    async.timesSeries = function (count, iterator, callback) {
+        var counter = [];
+        for (var i = 0; i < count; i++) {
+            counter.push(i);
+        }
+        return async.mapSeries(counter, iterator, callback);
+    };
+
+    async.compose = function (/* functions... */) {
+        var fns = Array.prototype.reverse.call(arguments);
+        return function () {
+            var that = this;
+            var args = Array.prototype.slice.call(arguments);
+            var callback = args.pop();
+            async.reduce(fns, args, function (newargs, fn, cb) {
+                fn.apply(that, newargs.concat([function () {
+                    var err = arguments[0];
+                    var nextargs = Array.prototype.slice.call(arguments, 1);
+                    cb(err, nextargs);
+                }]))
+            },
+            function (err, results) {
+                callback.apply(that, [err].concat(results));
+            });
+        };
+    };
+
+    var _applyEach = function (eachfn, fns /*args...*/) {
+        var go = function () {
+            var that = this;
+            var args = Array.prototype.slice.call(arguments);
+            var callback = args.pop();
+            return eachfn(fns, function (fn, cb) {
+                fn.apply(that, args.concat([cb]));
+            },
+            callback);
+        };
+        if (arguments.length > 2) {
+            var args = Array.prototype.slice.call(arguments, 2);
+            return go.apply(this, args);
+        }
+        else {
+            return go;
+        }
+    };
+    async.applyEach = doParallel(_applyEach);
+    async.applyEachSeries = doSeries(_applyEach);
+
+    async.forever = function (fn, callback) {
+        function next(err) {
+            if (err) {
+                if (callback) {
+                    return callback(err);
+                }
+                throw err;
+            }
+            fn(next);
+        }
+        next();
+    };
+
+    // AMD / RequireJS
+    if (typeof define !== 'undefined' && define.amd) {
+        define([], function () {
+            return async;
+        });
+    }
+    // Node.js
+    else if (typeof module !== 'undefined' && module.exports) {
+        module.exports = async;
+    }
+    // included directly via <script> tag
+    else {
+        root.async = async;
+    }
+
+}());

--- a/src/main/resources/static/bower/async/nodelint.cfg
+++ b/src/main/resources/static/bower/async/nodelint.cfg
@@ -1,0 +1,4 @@
+var options = {
+    indent: 4,
+    onevar: false
+};

--- a/src/main/resources/static/bower/async/package.json
+++ b/src/main/resources/static/bower/async/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "async",
+    "description": "Higher-order functions and common patterns for asynchronous code",
+    "main": "./lib/async",
+    "author": "Caolan McMahon",
+    "version": "0.2.10",
+    "repository" : {
+        "type" : "git",
+        "url" : "https://github.com/caolan/async.git"
+    },
+    "bugs" : {
+        "url" : "https://github.com/caolan/async/issues"
+    },
+    "licenses" : [
+        {
+            "type" : "MIT",
+            "url" : "https://github.com/caolan/async/raw/master/LICENSE"
+        }
+    ],
+    "devDependencies": {
+        "nodeunit": ">0.0.0",
+        "uglify-js": "1.2.x",
+        "nodelint": ">0.0.0"
+    },
+    "jam": {
+        "main": "lib/async.js",
+        "include": [
+            "lib/async.js",
+            "README.md",
+            "LICENSE"
+        ]
+    },
+    "scripts": {
+        "test": "nodeunit test/test-async.js"
+    }
+}

--- a/src/main/resources/static/bower/async/test/test-async.js
+++ b/src/main/resources/static/bower/async/test/test-async.js
@@ -1,0 +1,2438 @@
+var async = require('../lib/async');
+
+if (!Function.prototype.bind) {
+    Function.prototype.bind = function (thisArg) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        var self = this;
+        return function () {
+            self.apply(thisArg, args.concat(Array.prototype.slice.call(arguments)));
+        }
+    };
+}
+
+function eachIterator(args, x, callback) {
+    setTimeout(function(){
+        args.push(x);
+        callback();
+    }, x*25);
+}
+
+function mapIterator(call_order, x, callback) {
+    setTimeout(function(){
+        call_order.push(x);
+        callback(null, x*2);
+    }, x*25);
+}
+
+function filterIterator(x, callback) {
+    setTimeout(function(){
+        callback(x % 2);
+    }, x*25);
+}
+
+function detectIterator(call_order, x, callback) {
+    setTimeout(function(){
+        call_order.push(x);
+        callback(x == 2);
+    }, x*25);
+}
+
+function eachNoCallbackIterator(test, x, callback) {
+    test.equal(x, 1);
+    callback();
+    test.done();
+}
+
+function getFunctionsObject(call_order) {
+    return {
+        one: function(callback){
+            setTimeout(function(){
+                call_order.push(1);
+                callback(null, 1);
+            }, 125);
+        },
+        two: function(callback){
+            setTimeout(function(){
+                call_order.push(2);
+                callback(null, 2);
+            }, 200);
+        },
+        three: function(callback){
+            setTimeout(function(){
+                call_order.push(3);
+                callback(null, 3,3);
+            }, 50);
+        }
+    };
+}
+
+exports['forever'] = function (test) {
+    test.expect(1);
+    var counter = 0;
+    function addOne(callback) {
+        counter++;
+        if (counter === 50) {
+            return callback('too big!');
+        }
+        async.setImmediate(function () {
+            callback();
+        });
+    }
+    async.forever(addOne, function (err) {
+        test.equal(err, 'too big!');
+        test.done();
+    });
+};
+
+exports['applyEach'] = function (test) {
+    test.expect(4);
+    var call_order = [];
+    var one = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('one');
+            cb(null, 1);
+        }, 100);
+    };
+    var two = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('two');
+            cb(null, 2);
+        }, 50);
+    };
+    var three = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('three');
+            cb(null, 3);
+        }, 150);
+    };
+    async.applyEach([one, two, three], 5, function (err) {
+        test.same(call_order, ['two', 'one', 'three']);
+        test.done();
+    });
+};
+
+exports['applyEachSeries'] = function (test) {
+    test.expect(4);
+    var call_order = [];
+    var one = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('one');
+            cb(null, 1);
+        }, 100);
+    };
+    var two = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('two');
+            cb(null, 2);
+        }, 50);
+    };
+    var three = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('three');
+            cb(null, 3);
+        }, 150);
+    };
+    async.applyEachSeries([one, two, three], 5, function (err) {
+        test.same(call_order, ['one', 'two', 'three']);
+        test.done();
+    });
+};
+
+exports['applyEach partial application'] = function (test) {
+    test.expect(4);
+    var call_order = [];
+    var one = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('one');
+            cb(null, 1);
+        }, 100);
+    };
+    var two = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('two');
+            cb(null, 2);
+        }, 50);
+    };
+    var three = function (val, cb) {
+        test.equal(val, 5);
+        setTimeout(function () {
+            call_order.push('three');
+            cb(null, 3);
+        }, 150);
+    };
+    async.applyEach([one, two, three])(5, function (err) {
+        test.same(call_order, ['two', 'one', 'three']);
+        test.done();
+    });
+};
+
+exports['compose'] = function (test) {
+    test.expect(4);
+    var add2 = function (n, cb) {
+        test.equal(n, 3);
+        setTimeout(function () {
+            cb(null, n + 2);
+        }, 50);
+    };
+    var mul3 = function (n, cb) {
+        test.equal(n, 5);
+        setTimeout(function () {
+            cb(null, n * 3);
+        }, 15);
+    };
+    var add1 = function (n, cb) {
+        test.equal(n, 15);
+        setTimeout(function () {
+            cb(null, n + 1);
+        }, 100);
+    };
+    var add2mul3add1 = async.compose(add1, mul3, add2);
+    add2mul3add1(3, function (err, result) {
+        if (err) {
+            return test.done(err);
+        }
+        test.equal(result, 16);
+        test.done();
+    });
+};
+
+exports['compose error'] = function (test) {
+    test.expect(3);
+    var testerr = new Error('test');
+
+    var add2 = function (n, cb) {
+        test.equal(n, 3);
+        setTimeout(function () {
+            cb(null, n + 2);
+        }, 50);
+    };
+    var mul3 = function (n, cb) {
+        test.equal(n, 5);
+        setTimeout(function () {
+            cb(testerr);
+        }, 15);
+    };
+    var add1 = function (n, cb) {
+        test.ok(false, 'add1 should not get called');
+        setTimeout(function () {
+            cb(null, n + 1);
+        }, 100);
+    };
+    var add2mul3add1 = async.compose(add1, mul3, add2);
+    add2mul3add1(3, function (err, result) {
+        test.equal(err, testerr);
+        test.done();
+    });
+};
+
+exports['compose binding'] = function (test) {
+    test.expect(4);
+    var testerr = new Error('test');
+    var testcontext = {name: 'foo'};
+
+    var add2 = function (n, cb) {
+        test.equal(this, testcontext);
+        setTimeout(function () {
+            cb(null, n + 2);
+        }, 50);
+    };
+    var mul3 = function (n, cb) {
+        test.equal(this, testcontext);
+        setTimeout(function () {
+            cb(null, n * 3);
+        }, 15);
+    };
+    var add2mul3 = async.compose(mul3, add2);
+    add2mul3.call(testcontext, 3, function (err, result) {
+        if (err) {
+            return test.done(err);
+        }
+        test.equal(this, testcontext);
+        test.equal(result, 15);
+        test.done();
+    });
+};
+
+exports['auto'] = function(test){
+    var callOrder = [];
+    var testdata = [{test: 'test'}];
+    async.auto({
+        task1: ['task2', function(callback){
+            setTimeout(function(){
+                callOrder.push('task1');
+                callback();
+            }, 25);
+        }],
+        task2: function(callback){
+            setTimeout(function(){
+                callOrder.push('task2');
+                callback();
+            }, 50);
+        },
+        task3: ['task2', function(callback){
+            callOrder.push('task3');
+            callback();
+        }],
+        task4: ['task1', 'task2', function(callback){
+            callOrder.push('task4');
+            callback();
+        }],
+        task5: ['task2', function(callback){
+            setTimeout(function(){
+              callOrder.push('task5');
+              callback();
+            }, 0);
+        }],
+        task6: ['task2', function(callback){
+            callOrder.push('task6');
+            callback();
+        }]
+    },
+    function(err){
+        test.same(callOrder, ['task2','task6','task3','task5','task1','task4']);
+        test.done();
+    });
+};
+
+exports['auto petrify'] = function (test) {
+    var callOrder = [];
+    async.auto({
+        task1: ['task2', function (callback) {
+            setTimeout(function () {
+                callOrder.push('task1');
+                callback();
+            }, 100);
+        }],
+        task2: function (callback) {
+            setTimeout(function () {
+                callOrder.push('task2');
+                callback();
+            }, 200);
+        },
+        task3: ['task2', function (callback) {
+            callOrder.push('task3');
+            callback();
+        }],
+        task4: ['task1', 'task2', function (callback) {
+            callOrder.push('task4');
+            callback();
+        }]
+    },
+    function (err) {
+        test.same(callOrder, ['task2', 'task3', 'task1', 'task4']);
+        test.done();
+    });
+};
+
+exports['auto results'] = function(test){
+    var callOrder = [];
+    async.auto({
+      task1: ['task2', function(callback, results){
+          test.same(results.task2, 'task2');
+          setTimeout(function(){
+              callOrder.push('task1');
+              callback(null, 'task1a', 'task1b');
+          }, 25);
+      }],
+      task2: function(callback){
+          setTimeout(function(){
+              callOrder.push('task2');
+              callback(null, 'task2');
+          }, 50);
+      },
+      task3: ['task2', function(callback, results){
+          test.same(results.task2, 'task2');
+          callOrder.push('task3');
+          callback(null);
+      }],
+      task4: ['task1', 'task2', function(callback, results){
+          test.same(results.task1, ['task1a','task1b']);
+          test.same(results.task2, 'task2');
+          callOrder.push('task4');
+          callback(null, 'task4');
+      }]
+    },
+    function(err, results){
+        test.same(callOrder, ['task2','task3','task1','task4']);
+        test.same(results, {task1: ['task1a','task1b'], task2: 'task2', task3: undefined, task4: 'task4'});
+        test.done();
+    });
+};
+
+
+exports['auto empty object'] = function(test){
+    async.auto({}, function(err){
+        test.done();
+    });
+};
+
+exports['auto error'] = function(test){
+    test.expect(1);
+    async.auto({
+        task1: function(callback){
+            callback('testerror');
+        },
+        task2: ['task1', function(callback){
+            test.ok(false, 'task2 should not be called');
+            callback();
+        }],
+        task3: function(callback){
+            callback('testerror2');
+        }
+    },
+    function(err){
+        test.equals(err, 'testerror');
+    });
+    setTimeout(test.done, 100);
+};
+
+exports['auto no callback'] = function(test){
+    async.auto({
+        task1: function(callback){callback();},
+        task2: ['task1', function(callback){callback(); test.done();}]
+    });
+};
+
+exports['auto error should pass partial results'] = function(test) {
+    async.auto({
+        task1: function(callback){
+            callback(false, 'result1');
+        },
+        task2: ['task1', function(callback){
+            callback('testerror', 'result2');
+        }],
+        task3: ['task2', function(callback){
+            test.ok(false, 'task3 should not be called');
+        }]
+    },
+    function(err, results){
+        test.equals(err, 'testerror');
+        test.equals(results.task1, 'result1');
+        test.equals(results.task2, 'result2');
+				test.done();
+    });
+};
+
+// Issue 24 on github: https://github.com/caolan/async/issues#issue/24
+// Issue 76 on github: https://github.com/caolan/async/issues#issue/76
+exports['auto removeListener has side effect on loop iterator'] = function(test) {
+    async.auto({
+        task1: ['task3', function(callback) { test.done() }],
+        task2: ['task3', function(callback) { /* by design: DON'T call callback */ }],
+        task3: function(callback) { callback(); }
+    });
+};
+
+exports['waterfall'] = function(test){
+    test.expect(6);
+    var call_order = [];
+    async.waterfall([
+        function(callback){
+            call_order.push('fn1');
+            setTimeout(function(){callback(null, 'one', 'two');}, 0);
+        },
+        function(arg1, arg2, callback){
+            call_order.push('fn2');
+            test.equals(arg1, 'one');
+            test.equals(arg2, 'two');
+            setTimeout(function(){callback(null, arg1, arg2, 'three');}, 25);
+        },
+        function(arg1, arg2, arg3, callback){
+            call_order.push('fn3');
+            test.equals(arg1, 'one');
+            test.equals(arg2, 'two');
+            test.equals(arg3, 'three');
+            callback(null, 'four');
+        },
+        function(arg4, callback){
+            call_order.push('fn4');
+            test.same(call_order, ['fn1','fn2','fn3','fn4']);
+            callback(null, 'test');
+        }
+    ], function(err){
+        test.done();
+    });
+};
+
+exports['waterfall empty array'] = function(test){
+    async.waterfall([], function(err){
+        test.done();
+    });
+};
+
+exports['waterfall non-array'] = function(test){
+    async.waterfall({}, function(err){
+        test.equals(err.message, 'First argument to waterfall must be an array of functions');
+        test.done();
+    });
+};
+
+exports['waterfall no callback'] = function(test){
+    async.waterfall([
+        function(callback){callback();},
+        function(callback){callback(); test.done();}
+    ]);
+};
+
+exports['waterfall async'] = function(test){
+    var call_order = [];
+    async.waterfall([
+        function(callback){
+            call_order.push(1);
+            callback();
+            call_order.push(2);
+        },
+        function(callback){
+            call_order.push(3);
+            callback();
+        },
+        function(){
+            test.same(call_order, [1,2,3]);
+            test.done();
+        }
+    ]);
+};
+
+exports['waterfall error'] = function(test){
+    test.expect(1);
+    async.waterfall([
+        function(callback){
+            callback('error');
+        },
+        function(callback){
+            test.ok(false, 'next function should not be called');
+            callback();
+        }
+    ], function(err){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['waterfall multiple callback calls'] = function(test){
+    var call_order = [];
+    var arr = [
+        function(callback){
+            call_order.push(1);
+            // call the callback twice. this should call function 2 twice
+            callback(null, 'one', 'two');
+            callback(null, 'one', 'two');
+        },
+        function(arg1, arg2, callback){
+            call_order.push(2);
+            callback(null, arg1, arg2, 'three');
+        },
+        function(arg1, arg2, arg3, callback){
+            call_order.push(3);
+            callback(null, 'four');
+        },
+        function(arg4){
+            call_order.push(4);
+            arr[3] = function(){
+                call_order.push(4);
+                test.same(call_order, [1,2,2,3,3,4,4]);
+                test.done();
+            };
+        }
+    ];
+    async.waterfall(arr);
+};
+
+
+exports['parallel'] = function(test){
+    var call_order = [];
+    async.parallel([
+        function(callback){
+            setTimeout(function(){
+                call_order.push(1);
+                callback(null, 1);
+            }, 50);
+        },
+        function(callback){
+            setTimeout(function(){
+                call_order.push(2);
+                callback(null, 2);
+            }, 100);
+        },
+        function(callback){
+            setTimeout(function(){
+                call_order.push(3);
+                callback(null, 3,3);
+            }, 25);
+        }
+    ],
+    function(err, results){
+        test.equals(err, null);
+        test.same(call_order, [3,1,2]);
+        test.same(results, [1,2,[3,3]]);
+        test.done();
+    });
+};
+
+exports['parallel empty array'] = function(test){
+    async.parallel([], function(err, results){
+        test.equals(err, null);
+        test.same(results, []);
+        test.done();
+    });
+};
+
+exports['parallel error'] = function(test){
+    async.parallel([
+        function(callback){
+            callback('error', 1);
+        },
+        function(callback){
+            callback('error2', 2);
+        }
+    ],
+    function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 100);
+};
+
+exports['parallel no callback'] = function(test){
+    async.parallel([
+        function(callback){callback();},
+        function(callback){callback(); test.done();},
+    ]);
+};
+
+exports['parallel object'] = function(test){
+    var call_order = [];
+    async.parallel(getFunctionsObject(call_order), function(err, results){
+        test.equals(err, null);
+        test.same(call_order, [3,1,2]);
+        test.same(results, {
+            one: 1,
+            two: 2,
+            three: [3,3]
+        });
+        test.done();
+    });
+};
+
+exports['parallel limit'] = function(test){
+    var call_order = [];
+    async.parallelLimit([
+        function(callback){
+            setTimeout(function(){
+                call_order.push(1);
+                callback(null, 1);
+            }, 50);
+        },
+        function(callback){
+            setTimeout(function(){
+                call_order.push(2);
+                callback(null, 2);
+            }, 100);
+        },
+        function(callback){
+            setTimeout(function(){
+                call_order.push(3);
+                callback(null, 3,3);
+            }, 25);
+        }
+    ],
+    2,
+    function(err, results){
+        test.equals(err, null);
+        test.same(call_order, [1,3,2]);
+        test.same(results, [1,2,[3,3]]);
+        test.done();
+    });
+};
+
+exports['parallel limit empty array'] = function(test){
+    async.parallelLimit([], 2, function(err, results){
+        test.equals(err, null);
+        test.same(results, []);
+        test.done();
+    });
+};
+
+exports['parallel limit error'] = function(test){
+    async.parallelLimit([
+        function(callback){
+            callback('error', 1);
+        },
+        function(callback){
+            callback('error2', 2);
+        }
+    ],
+    1,
+    function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 100);
+};
+
+exports['parallel limit no callback'] = function(test){
+    async.parallelLimit([
+        function(callback){callback();},
+        function(callback){callback(); test.done();},
+    ], 1);
+};
+
+exports['parallel limit object'] = function(test){
+    var call_order = [];
+    async.parallelLimit(getFunctionsObject(call_order), 2, function(err, results){
+        test.equals(err, null);
+        test.same(call_order, [1,3,2]);
+        test.same(results, {
+            one: 1,
+            two: 2,
+            three: [3,3]
+        });
+        test.done();
+    });
+};
+
+exports['series'] = function(test){
+    var call_order = [];
+    async.series([
+        function(callback){
+            setTimeout(function(){
+                call_order.push(1);
+                callback(null, 1);
+            }, 25);
+        },
+        function(callback){
+            setTimeout(function(){
+                call_order.push(2);
+                callback(null, 2);
+            }, 50);
+        },
+        function(callback){
+            setTimeout(function(){
+                call_order.push(3);
+                callback(null, 3,3);
+            }, 15);
+        }
+    ],
+    function(err, results){
+        test.equals(err, null);
+        test.same(results, [1,2,[3,3]]);
+        test.same(call_order, [1,2,3]);
+        test.done();
+    });
+};
+
+exports['series empty array'] = function(test){
+    async.series([], function(err, results){
+        test.equals(err, null);
+        test.same(results, []);
+        test.done();
+    });
+};
+
+exports['series error'] = function(test){
+    test.expect(1);
+    async.series([
+        function(callback){
+            callback('error', 1);
+        },
+        function(callback){
+            test.ok(false, 'should not be called');
+            callback('error2', 2);
+        }
+    ],
+    function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 100);
+};
+
+exports['series no callback'] = function(test){
+    async.series([
+        function(callback){callback();},
+        function(callback){callback(); test.done();},
+    ]);
+};
+
+exports['series object'] = function(test){
+    var call_order = [];
+    async.series(getFunctionsObject(call_order), function(err, results){
+        test.equals(err, null);
+        test.same(results, {
+            one: 1,
+            two: 2,
+            three: [3,3]
+        });
+        test.same(call_order, [1,2,3]);
+        test.done();
+    });
+};
+
+exports['iterator'] = function(test){
+    var call_order = [];
+    var iterator = async.iterator([
+        function(){call_order.push(1);},
+        function(arg1){
+            test.equals(arg1, 'arg1');
+            call_order.push(2);
+        },
+        function(arg1, arg2){
+            test.equals(arg1, 'arg1');
+            test.equals(arg2, 'arg2');
+            call_order.push(3);
+        }
+    ]);
+    iterator();
+    test.same(call_order, [1]);
+    var iterator2 = iterator();
+    test.same(call_order, [1,1]);
+    var iterator3 = iterator2('arg1');
+    test.same(call_order, [1,1,2]);
+    var iterator4 = iterator3('arg1', 'arg2');
+    test.same(call_order, [1,1,2,3]);
+    test.equals(iterator4, undefined);
+    test.done();
+};
+
+exports['iterator empty array'] = function(test){
+    var iterator = async.iterator([]);
+    test.equals(iterator(), undefined);
+    test.equals(iterator.next(), undefined);
+    test.done();
+};
+
+exports['iterator.next'] = function(test){
+    var call_order = [];
+    var iterator = async.iterator([
+        function(){call_order.push(1);},
+        function(arg1){
+            test.equals(arg1, 'arg1');
+            call_order.push(2);
+        },
+        function(arg1, arg2){
+            test.equals(arg1, 'arg1');
+            test.equals(arg2, 'arg2');
+            call_order.push(3);
+        }
+    ]);
+    var fn = iterator.next();
+    var iterator2 = fn('arg1');
+    test.same(call_order, [2]);
+    iterator2('arg1','arg2');
+    test.same(call_order, [2,3]);
+    test.equals(iterator2.next(), undefined);
+    test.done();
+};
+
+exports['each'] = function(test){
+    var args = [];
+    async.each([1,3,2], eachIterator.bind(this, args), function(err){
+        test.same(args, [1,2,3]);
+        test.done();
+    });
+};
+
+exports['each extra callback'] = function(test){
+    var count = 0;
+    async.each([1,3,2], function(val, callback) {
+        count++;
+        callback();
+        test.throws(callback);
+        if (count == 3) {
+            test.done();
+        }
+    });
+};
+
+exports['each empty array'] = function(test){
+    test.expect(1);
+    async.each([], function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['each error'] = function(test){
+    test.expect(1);
+    async.each([1,2,3], function(x, callback){
+        callback('error');
+    }, function(err){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['each no callback'] = function(test){
+    async.each([1], eachNoCallbackIterator.bind(this, test));
+};
+
+exports['forEach alias'] = function (test) {
+    test.strictEqual(async.each, async.forEach);
+    test.done();
+};
+
+exports['eachSeries'] = function(test){
+    var args = [];
+    async.eachSeries([1,3,2], eachIterator.bind(this, args), function(err){
+        test.same(args, [1,3,2]);
+        test.done();
+    });
+};
+
+exports['eachSeries empty array'] = function(test){
+    test.expect(1);
+    async.eachSeries([], function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['eachSeries error'] = function(test){
+    test.expect(2);
+    var call_order = [];
+    async.eachSeries([1,2,3], function(x, callback){
+        call_order.push(x);
+        callback('error');
+    }, function(err){
+        test.same(call_order, [1]);
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['eachSeries no callback'] = function(test){
+    async.eachSeries([1], eachNoCallbackIterator.bind(this, test));
+};
+
+exports['forEachSeries alias'] = function (test) {
+    test.strictEqual(async.eachSeries, async.forEachSeries);
+    test.done();
+};
+
+exports['eachLimit'] = function(test){
+    var args = [];
+    var arr = [0,1,2,3,4,5,6,7,8,9];
+    async.eachLimit(arr, 2, function(x,callback){
+        setTimeout(function(){
+            args.push(x);
+            callback();
+        }, x*5);
+    }, function(err){
+        test.same(args, arr);
+        test.done();
+    });
+};
+
+exports['eachLimit empty array'] = function(test){
+    test.expect(1);
+    async.eachLimit([], 2, function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['eachLimit limit exceeds size'] = function(test){
+    var args = [];
+    var arr = [0,1,2,3,4,5,6,7,8,9];
+    async.eachLimit(arr, 20, eachIterator.bind(this, args), function(err){
+        test.same(args, arr);
+        test.done();
+    });
+};
+
+exports['eachLimit limit equal size'] = function(test){
+    var args = [];
+    var arr = [0,1,2,3,4,5,6,7,8,9];
+    async.eachLimit(arr, 10, eachIterator.bind(this, args), function(err){
+        test.same(args, arr);
+        test.done();
+    });
+};
+
+exports['eachLimit zero limit'] = function(test){
+    test.expect(1);
+    async.eachLimit([0,1,2,3,4,5], 0, function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['eachLimit error'] = function(test){
+    test.expect(2);
+    var arr = [0,1,2,3,4,5,6,7,8,9];
+    var call_order = [];
+
+    async.eachLimit(arr, 3, function(x, callback){
+        call_order.push(x);
+        if (x === 2) {
+            callback('error');
+        }
+    }, function(err){
+        test.same(call_order, [0,1,2]);
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['eachLimit no callback'] = function(test){
+    async.eachLimit([1], 1, eachNoCallbackIterator.bind(this, test));
+};
+
+exports['eachLimit synchronous'] = function(test){
+    var args = [];
+    var arr = [0,1,2];
+    async.eachLimit(arr, 5, function(x,callback){
+        args.push(x);
+        callback();
+    }, function(err){
+        test.same(args, arr);
+        test.done();
+    });
+};
+
+exports['forEachLimit alias'] = function (test) {
+    test.strictEqual(async.eachLimit, async.forEachLimit);
+    test.done();
+};
+
+exports['map'] = function(test){
+    var call_order = [];
+    async.map([1,3,2], mapIterator.bind(this, call_order), function(err, results){
+        test.same(call_order, [1,2,3]);
+        test.same(results, [2,6,4]);
+        test.done();
+    });
+};
+
+exports['map original untouched'] = function(test){
+    var a = [1,2,3];
+    async.map(a, function(x, callback){
+        callback(null, x*2);
+    }, function(err, results){
+        test.same(results, [2,4,6]);
+        test.same(a, [1,2,3]);
+        test.done();
+    });
+};
+
+exports['map error'] = function(test){
+    test.expect(1);
+    async.map([1,2,3], function(x, callback){
+        callback('error');
+    }, function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['mapSeries'] = function(test){
+    var call_order = [];
+    async.mapSeries([1,3,2], mapIterator.bind(this, call_order), function(err, results){
+        test.same(call_order, [1,3,2]);
+        test.same(results, [2,6,4]);
+        test.done();
+    });
+};
+
+exports['mapSeries error'] = function(test){
+    test.expect(1);
+    async.mapSeries([1,2,3], function(x, callback){
+        callback('error');
+    }, function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+
+exports['mapLimit'] = function(test){
+    var call_order = [];
+    async.mapLimit([2,4,3], 2, mapIterator.bind(this, call_order), function(err, results){
+        test.same(call_order, [2,4,3]);
+        test.same(results, [4,8,6]);
+        test.done();
+    });
+};
+
+exports['mapLimit empty array'] = function(test){
+    test.expect(1);
+    async.mapLimit([], 2, function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['mapLimit limit exceeds size'] = function(test){
+    var call_order = [];
+    async.mapLimit([0,1,2,3,4,5,6,7,8,9], 20, mapIterator.bind(this, call_order), function(err, results){
+        test.same(call_order, [0,1,2,3,4,5,6,7,8,9]);
+        test.same(results, [0,2,4,6,8,10,12,14,16,18]);
+        test.done();
+    });
+};
+
+exports['mapLimit limit equal size'] = function(test){
+    var call_order = [];
+    async.mapLimit([0,1,2,3,4,5,6,7,8,9], 10, mapIterator.bind(this, call_order), function(err, results){
+        test.same(call_order, [0,1,2,3,4,5,6,7,8,9]);
+        test.same(results, [0,2,4,6,8,10,12,14,16,18]);
+        test.done();
+    });
+};
+
+exports['mapLimit zero limit'] = function(test){
+    test.expect(2);
+    async.mapLimit([0,1,2,3,4,5], 0, function(x, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err, results){
+        test.same(results, []);
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['mapLimit error'] = function(test){
+    test.expect(2);
+    var arr = [0,1,2,3,4,5,6,7,8,9];
+    var call_order = [];
+
+    async.mapLimit(arr, 3, function(x, callback){
+        call_order.push(x);
+        if (x === 2) {
+            callback('error');
+        }
+    }, function(err){
+        test.same(call_order, [0,1,2]);
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 25);
+};
+
+
+exports['reduce'] = function(test){
+    var call_order = [];
+    async.reduce([1,2,3], 0, function(a, x, callback){
+        call_order.push(x);
+        callback(null, a + x);
+    }, function(err, result){
+        test.equals(result, 6);
+        test.same(call_order, [1,2,3]);
+        test.done();
+    });
+};
+
+exports['reduce async with non-reference memo'] = function(test){
+    async.reduce([1,3,2], 0, function(a, x, callback){
+        setTimeout(function(){callback(null, a + x)}, Math.random()*100);
+    }, function(err, result){
+        test.equals(result, 6);
+        test.done();
+    });
+};
+
+exports['reduce error'] = function(test){
+    test.expect(1);
+    async.reduce([1,2,3], 0, function(a, x, callback){
+        callback('error');
+    }, function(err, result){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['inject alias'] = function(test){
+    test.equals(async.inject, async.reduce);
+    test.done();
+};
+
+exports['foldl alias'] = function(test){
+    test.equals(async.foldl, async.reduce);
+    test.done();
+};
+
+exports['reduceRight'] = function(test){
+    var call_order = [];
+    var a = [1,2,3];
+    async.reduceRight(a, 0, function(a, x, callback){
+        call_order.push(x);
+        callback(null, a + x);
+    }, function(err, result){
+        test.equals(result, 6);
+        test.same(call_order, [3,2,1]);
+        test.same(a, [1,2,3]);
+        test.done();
+    });
+};
+
+exports['foldr alias'] = function(test){
+    test.equals(async.foldr, async.reduceRight);
+    test.done();
+};
+
+exports['filter'] = function(test){
+    async.filter([3,1,2], filterIterator, function(results){
+        test.same(results, [3,1]);
+        test.done();
+    });
+};
+
+exports['filter original untouched'] = function(test){
+    var a = [3,1,2];
+    async.filter(a, function(x, callback){
+        callback(x % 2);
+    }, function(results){
+        test.same(results, [3,1]);
+        test.same(a, [3,1,2]);
+        test.done();
+    });
+};
+
+exports['filterSeries'] = function(test){
+    async.filterSeries([3,1,2], filterIterator, function(results){
+        test.same(results, [3,1]);
+        test.done();
+    });
+};
+
+exports['select alias'] = function(test){
+    test.equals(async.select, async.filter);
+    test.done();
+};
+
+exports['selectSeries alias'] = function(test){
+    test.equals(async.selectSeries, async.filterSeries);
+    test.done();
+};
+
+exports['reject'] = function(test){
+    async.reject([3,1,2], filterIterator, function(results){
+        test.same(results, [2]);
+        test.done();
+    });
+};
+
+exports['reject original untouched'] = function(test){
+    var a = [3,1,2];
+    async.reject(a, function(x, callback){
+        callback(x % 2);
+    }, function(results){
+        test.same(results, [2]);
+        test.same(a, [3,1,2]);
+        test.done();
+    });
+};
+
+exports['rejectSeries'] = function(test){
+    async.rejectSeries([3,1,2], filterIterator, function(results){
+        test.same(results, [2]);
+        test.done();
+    });
+};
+
+exports['some true'] = function(test){
+    async.some([3,1,2], function(x, callback){
+        setTimeout(function(){callback(x === 1);}, 0);
+    }, function(result){
+        test.equals(result, true);
+        test.done();
+    });
+};
+
+exports['some false'] = function(test){
+    async.some([3,1,2], function(x, callback){
+        setTimeout(function(){callback(x === 10);}, 0);
+    }, function(result){
+        test.equals(result, false);
+        test.done();
+    });
+};
+
+exports['some early return'] = function(test){
+    var call_order = [];
+    async.some([1,2,3], function(x, callback){
+        setTimeout(function(){
+            call_order.push(x);
+            callback(x === 1);
+        }, x*25);
+    }, function(result){
+        call_order.push('callback');
+    });
+    setTimeout(function(){
+        test.same(call_order, [1,'callback',2,3]);
+        test.done();
+    }, 100);
+};
+
+exports['any alias'] = function(test){
+    test.equals(async.any, async.some);
+    test.done();
+};
+
+exports['every true'] = function(test){
+    async.every([1,2,3], function(x, callback){
+        setTimeout(function(){callback(true);}, 0);
+    }, function(result){
+        test.equals(result, true);
+        test.done();
+    });
+};
+
+exports['every false'] = function(test){
+    async.every([1,2,3], function(x, callback){
+        setTimeout(function(){callback(x % 2);}, 0);
+    }, function(result){
+        test.equals(result, false);
+        test.done();
+    });
+};
+
+exports['every early return'] = function(test){
+    var call_order = [];
+    async.every([1,2,3], function(x, callback){
+        setTimeout(function(){
+            call_order.push(x);
+            callback(x === 1);
+        }, x*25);
+    }, function(result){
+        call_order.push('callback');
+    });
+    setTimeout(function(){
+        test.same(call_order, [1,2,'callback',3]);
+        test.done();
+    }, 100);
+};
+
+exports['all alias'] = function(test){
+    test.equals(async.all, async.every);
+    test.done();
+};
+
+exports['detect'] = function(test){
+    var call_order = [];
+    async.detect([3,2,1], detectIterator.bind(this, call_order), function(result){
+        call_order.push('callback');
+        test.equals(result, 2);
+    });
+    setTimeout(function(){
+        test.same(call_order, [1,2,'callback',3]);
+        test.done();
+    }, 100);
+};
+
+exports['detect - mulitple matches'] = function(test){
+    var call_order = [];
+    async.detect([3,2,2,1,2], detectIterator.bind(this, call_order), function(result){
+        call_order.push('callback');
+        test.equals(result, 2);
+    });
+    setTimeout(function(){
+        test.same(call_order, [1,2,'callback',2,2,3]);
+        test.done();
+    }, 100);
+};
+
+exports['detectSeries'] = function(test){
+    var call_order = [];
+    async.detectSeries([3,2,1], detectIterator.bind(this, call_order), function(result){
+        call_order.push('callback');
+        test.equals(result, 2);
+    });
+    setTimeout(function(){
+        test.same(call_order, [3,2,'callback']);
+        test.done();
+    }, 200);
+};
+
+exports['detectSeries - multiple matches'] = function(test){
+    var call_order = [];
+    async.detectSeries([3,2,2,1,2], detectIterator.bind(this, call_order), function(result){
+        call_order.push('callback');
+        test.equals(result, 2);
+    });
+    setTimeout(function(){
+        test.same(call_order, [3,2,'callback']);
+        test.done();
+    }, 200);
+};
+
+exports['sortBy'] = function(test){
+    async.sortBy([{a:1},{a:15},{a:6}], function(x, callback){
+        setTimeout(function(){callback(null, x.a);}, 0);
+    }, function(err, result){
+        test.same(result, [{a:1},{a:6},{a:15}]);
+        test.done();
+    });
+};
+
+exports['apply'] = function(test){
+    test.expect(6);
+    var fn = function(){
+        test.same(Array.prototype.slice.call(arguments), [1,2,3,4])
+    };
+    async.apply(fn, 1, 2, 3, 4)();
+    async.apply(fn, 1, 2, 3)(4);
+    async.apply(fn, 1, 2)(3, 4);
+    async.apply(fn, 1)(2, 3, 4);
+    async.apply(fn)(1, 2, 3, 4);
+    test.equals(
+        async.apply(function(name){return 'hello ' + name}, 'world')(),
+        'hello world'
+    );
+    test.done();
+};
+
+
+// generates tests for console functions such as async.log
+var console_fn_tests = function(name){
+
+    if (typeof console !== 'undefined') {
+        exports[name] = function(test){
+            test.expect(5);
+            var fn = function(arg1, callback){
+                test.equals(arg1, 'one');
+                setTimeout(function(){callback(null, 'test');}, 0);
+            };
+            var fn_err = function(arg1, callback){
+                test.equals(arg1, 'one');
+                setTimeout(function(){callback('error');}, 0);
+            };
+            var _console_fn = console[name];
+            var _error = console.error;
+            console[name] = function(val){
+                test.equals(val, 'test');
+                test.equals(arguments.length, 1);
+                console.error = function(val){
+                    test.equals(val, 'error');
+                    console[name] = _console_fn;
+                    console.error = _error;
+                    test.done();
+                };
+                async[name](fn_err, 'one');
+            };
+            async[name](fn, 'one');
+        };
+
+        exports[name + ' with multiple result params'] = function(test){
+            var fn = function(callback){callback(null,'one','two','three');};
+            var _console_fn = console[name];
+            var called_with = [];
+            console[name] = function(x){
+                called_with.push(x);
+            };
+            async[name](fn);
+            test.same(called_with, ['one','two','three']);
+            console[name] = _console_fn;
+            test.done();
+        };
+    }
+
+    // browser-only test
+    exports[name + ' without console.' + name] = function(test){
+        if (typeof window !== 'undefined') {
+            var _console = window.console;
+            window.console = undefined;
+            var fn = function(callback){callback(null, 'val');};
+            var fn_err = function(callback){callback('error');};
+            async[name](fn);
+            async[name](fn_err);
+            window.console = _console;
+        }
+        test.done();
+    };
+
+};
+
+
+
+exports['times'] = function(test) {
+  var indices = []
+  async.times(5, function(n, next) {
+    next(null, n)
+  }, function(err, results) {
+    test.same(results, [0,1,2,3,4])
+    test.done()
+  })
+}
+
+exports['times'] = function(test){
+    var args = [];
+    async.times(3, function(n, callback){
+        setTimeout(function(){
+            args.push(n);
+            callback();
+        }, n * 25);
+    }, function(err){
+        test.same(args, [0,1,2]);
+        test.done();
+    });
+};
+
+exports['times 0'] = function(test){
+    test.expect(1);
+    async.times(0, function(n, callback){
+        test.ok(false, 'iterator should not be called');
+        callback();
+    }, function(err){
+        test.ok(true, 'should call callback');
+    });
+    setTimeout(test.done, 25);
+};
+
+exports['times error'] = function(test){
+    test.expect(1);
+    async.times(3, function(n, callback){
+        callback('error');
+    }, function(err){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+exports['timesSeries'] = function(test){
+    var call_order = [];
+    async.timesSeries(5, function(n, callback){
+        setTimeout(function(){
+            call_order.push(n);
+            callback(null, n);
+        }, 100 - n * 10);
+    }, function(err, results){
+        test.same(call_order, [0,1,2,3,4]);
+        test.same(results, [0,1,2,3,4]);
+        test.done();
+    });
+};
+
+exports['timesSeries error'] = function(test){
+    test.expect(1);
+    async.timesSeries(5, function(n, callback){
+        callback('error');
+    }, function(err, results){
+        test.equals(err, 'error');
+    });
+    setTimeout(test.done, 50);
+};
+
+console_fn_tests('log');
+console_fn_tests('dir');
+/*console_fn_tests('info');
+console_fn_tests('warn');
+console_fn_tests('error');*/
+
+exports['nextTick'] = function(test){
+    var call_order = [];
+    async.nextTick(function(){call_order.push('two');});
+    call_order.push('one');
+    setTimeout(function(){
+        test.same(call_order, ['one','two']);
+        test.done();
+    }, 50);
+};
+
+exports['nextTick in the browser'] = function(test){
+    if (typeof process !== 'undefined') {
+        // skip this test in node
+        return test.done();
+    }
+    test.expect(1);
+
+    var call_order = [];
+    async.nextTick(function(){call_order.push('two');});
+
+    call_order.push('one');
+    setTimeout(function(){
+        if (typeof process !== 'undefined') {
+            process.nextTick = _nextTick;
+        }
+        test.same(call_order, ['one','two']);
+    }, 50);
+    setTimeout(test.done, 100);
+};
+
+exports['noConflict - node only'] = function(test){
+    if (typeof process !== 'undefined') {
+        // node only test
+        test.expect(3);
+        var fs = require('fs');
+        var filename = __dirname + '/../lib/async.js';
+        fs.readFile(filename, function(err, content){
+            if(err) return test.done();
+
+            // Script -> NodeScript in node v0.6.x
+            var Script = process.binding('evals').Script || process.binding('evals').NodeScript;
+
+            var s = new Script(content, filename);
+            var s2 = new Script(
+                content + 'this.async2 = this.async.noConflict();',
+                filename
+            );
+
+            var sandbox1 = {async: 'oldvalue'};
+            s.runInNewContext(sandbox1);
+            test.ok(sandbox1.async);
+
+            var sandbox2 = {async: 'oldvalue'};
+            s2.runInNewContext(sandbox2);
+            test.equals(sandbox2.async, 'oldvalue');
+            test.ok(sandbox2.async2);
+
+            test.done();
+        });
+    }
+    else test.done();
+};
+
+exports['concat'] = function(test){
+    var call_order = [];
+    var iterator = function (x, cb) {
+        setTimeout(function(){
+            call_order.push(x);
+            var r = [];
+            while (x > 0) {
+                r.push(x);
+                x--;
+            }
+            cb(null, r);
+        }, x*25);
+    };
+    async.concat([1,3,2], iterator, function(err, results){
+        test.same(results, [1,2,1,3,2,1]);
+        test.same(call_order, [1,2,3]);
+        test.ok(!err);
+        test.done();
+    });
+};
+
+exports['concat error'] = function(test){
+    var iterator = function (x, cb) {
+        cb(new Error('test error'));
+    };
+    async.concat([1,2,3], iterator, function(err, results){
+        test.ok(err);
+        test.done();
+    });
+};
+
+exports['concatSeries'] = function(test){
+    var call_order = [];
+    var iterator = function (x, cb) {
+        setTimeout(function(){
+            call_order.push(x);
+            var r = [];
+            while (x > 0) {
+                r.push(x);
+                x--;
+            }
+            cb(null, r);
+        }, x*25);
+    };
+    async.concatSeries([1,3,2], iterator, function(err, results){
+        test.same(results, [1,3,2,1,2,1]);
+        test.same(call_order, [1,3,2]);
+        test.ok(!err);
+        test.done();
+    });
+};
+
+exports['until'] = function (test) {
+    var call_order = [];
+
+    var count = 0;
+    async.until(
+        function () {
+            call_order.push(['test', count]);
+            return (count == 5);
+        },
+        function (cb) {
+            call_order.push(['iterator', count]);
+            count++;
+            cb();
+        },
+        function (err) {
+            test.same(call_order, [
+                ['test', 0],
+                ['iterator', 0], ['test', 1],
+                ['iterator', 1], ['test', 2],
+                ['iterator', 2], ['test', 3],
+                ['iterator', 3], ['test', 4],
+                ['iterator', 4], ['test', 5],
+            ]);
+            test.equals(count, 5);
+            test.done();
+        }
+    );
+};
+
+exports['doUntil'] = function (test) {
+    var call_order = [];
+    var count = 0;
+    async.doUntil(
+        function (cb) {
+            debugger
+            call_order.push(['iterator', count]);
+            count++;
+            cb();
+        },
+        function () {
+            call_order.push(['test', count]);
+            return (count == 5);
+        },
+        function (err) {
+            test.same(call_order, [
+                ['iterator', 0], ['test', 1],
+                ['iterator', 1], ['test', 2],
+                ['iterator', 2], ['test', 3],
+                ['iterator', 3], ['test', 4],
+                ['iterator', 4], ['test', 5]
+            ]);
+            test.equals(count, 5);
+            test.done();
+        }
+    );
+};
+
+exports['whilst'] = function (test) {
+    var call_order = [];
+
+    var count = 0;
+    async.whilst(
+        function () {
+            call_order.push(['test', count]);
+            return (count < 5);
+        },
+        function (cb) {
+            call_order.push(['iterator', count]);
+            count++;
+            cb();
+        },
+        function (err) {
+            test.same(call_order, [
+                ['test', 0],
+                ['iterator', 0], ['test', 1],
+                ['iterator', 1], ['test', 2],
+                ['iterator', 2], ['test', 3],
+                ['iterator', 3], ['test', 4],
+                ['iterator', 4], ['test', 5],
+            ]);
+            test.equals(count, 5);
+            test.done();
+        }
+    );
+};
+
+exports['doWhilst'] = function (test) {
+    var call_order = [];
+
+    var count = 0;
+    async.doWhilst(
+        function (cb) {
+            call_order.push(['iterator', count]);
+            count++;
+            cb();
+        },
+        function () {
+            call_order.push(['test', count]);
+            return (count < 5);
+        },
+        function (err) {
+            debugger
+            test.same(call_order, [
+                ['iterator', 0], ['test', 1],
+                ['iterator', 1], ['test', 2],
+                ['iterator', 2], ['test', 3],
+                ['iterator', 3], ['test', 4],
+                ['iterator', 4], ['test', 5]
+            ]);
+            test.equals(count, 5);
+            test.done();
+        }
+    );
+};
+
+exports['queue'] = function (test) {
+    var call_order = [],
+        delays = [160,80,240,80];
+
+    // worker1: --1-4
+    // worker2: -2---3
+    // order of completion: 2,1,4,3
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + task);
+            callback('error', 'arg');
+        }, delays.splice(0,1)[0]);
+    }, 2);
+
+    q.push(1, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 1);
+        call_order.push('callback ' + 1);
+    });
+    q.push(2, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 2);
+        call_order.push('callback ' + 2);
+    });
+    q.push(3, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 0);
+        call_order.push('callback ' + 3);
+    });
+    q.push(4, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 0);
+        call_order.push('callback ' + 4);
+    });
+    test.equal(q.length(), 4);
+    test.equal(q.concurrency, 2);
+
+    q.drain = function () {
+        test.same(call_order, [
+            'process 2', 'callback 2',
+            'process 1', 'callback 1',
+            'process 4', 'callback 4',
+            'process 3', 'callback 3'
+        ]);
+        test.equal(q.concurrency, 2);
+        test.equal(q.length(), 0);
+        test.done();
+    };
+};
+
+exports['queue default concurrency'] = function (test) {
+    var call_order = [],
+        delays = [160,80,240,80];
+
+    // order of completion: 1,2,3,4
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + task);
+            callback('error', 'arg');
+        }, delays.splice(0,1)[0]);
+    });
+
+    q.push(1, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 3);
+        call_order.push('callback ' + 1);
+    });
+    q.push(2, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 2);
+        call_order.push('callback ' + 2);
+    });
+    q.push(3, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 1);
+        call_order.push('callback ' + 3);
+    });
+    q.push(4, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 0);
+        call_order.push('callback ' + 4);
+    });
+    test.equal(q.length(), 4);
+    test.equal(q.concurrency, 1);
+
+    q.drain = function () {
+        test.same(call_order, [
+            'process 1', 'callback 1',
+            'process 2', 'callback 2',
+            'process 3', 'callback 3',
+            'process 4', 'callback 4'
+        ]);
+        test.equal(q.concurrency, 1);
+        test.equal(q.length(), 0);
+        test.done();
+    };
+};
+
+exports['queue error propagation'] = function(test){
+    var results = [];
+
+    var q = async.queue(function (task, callback) {
+        callback(task.name === 'foo' ? new Error('fooError') : null);
+    }, 2);
+
+    q.drain = function() {
+        test.deepEqual(results, ['bar', 'fooError']);
+        test.done();
+    };
+
+    q.push({name: 'bar'}, function (err) {
+        if(err) {
+            results.push('barError');
+            return;
+        }
+
+        results.push('bar');
+    });
+
+    q.push({name: 'foo'}, function (err) {
+        if(err) {
+            results.push('fooError');
+            return;
+        }
+
+        results.push('foo');
+    });
+};
+
+exports['queue changing concurrency'] = function (test) {
+    var call_order = [],
+        delays = [40,20,60,20];
+
+    // worker1: --1-2---3-4
+    // order of completion: 1,2,3,4
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + task);
+            callback('error', 'arg');
+        }, delays.splice(0,1)[0]);
+    }, 2);
+
+    q.push(1, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 3);
+        call_order.push('callback ' + 1);
+    });
+    q.push(2, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 2);
+        call_order.push('callback ' + 2);
+    });
+    q.push(3, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 1);
+        call_order.push('callback ' + 3);
+    });
+    q.push(4, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(q.length(), 0);
+        call_order.push('callback ' + 4);
+    });
+    test.equal(q.length(), 4);
+    test.equal(q.concurrency, 2);
+    q.concurrency = 1;
+
+    setTimeout(function () {
+        test.same(call_order, [
+            'process 1', 'callback 1',
+            'process 2', 'callback 2',
+            'process 3', 'callback 3',
+            'process 4', 'callback 4'
+        ]);
+        test.equal(q.concurrency, 1);
+        test.equal(q.length(), 0);
+        test.done();
+    }, 250);
+};
+
+exports['queue push without callback'] = function (test) {
+    var call_order = [],
+        delays = [160,80,240,80];
+
+    // worker1: --1-4
+    // worker2: -2---3
+    // order of completion: 2,1,4,3
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + task);
+            callback('error', 'arg');
+        }, delays.splice(0,1)[0]);
+    }, 2);
+
+    q.push(1);
+    q.push(2);
+    q.push(3);
+    q.push(4);
+
+    setTimeout(function () {
+        test.same(call_order, [
+            'process 2',
+            'process 1',
+            'process 4',
+            'process 3'
+        ]);
+        test.done();
+    }, 800);
+};
+
+exports['queue unshift'] = function (test) {
+    var queue_order = [];
+
+    var q = async.queue(function (task, callback) {
+      queue_order.push(task);
+      callback();
+    }, 1);
+
+    q.unshift(4);
+    q.unshift(3);
+    q.unshift(2);
+    q.unshift(1);
+
+    setTimeout(function () {
+        test.same(queue_order, [ 1, 2, 3, 4 ]);
+        test.done();
+    }, 100);
+};
+
+exports['queue too many callbacks'] = function (test) {
+    var q = async.queue(function (task, callback) {
+        callback();
+        test.throws(function() {
+            callback();
+        });
+        test.done();
+    }, 2);
+
+    q.push(1);
+};
+
+exports['queue bulk task'] = function (test) {
+    var call_order = [],
+        delays = [160,80,240,80];
+
+    // worker1: --1-4
+    // worker2: -2---3
+    // order of completion: 2,1,4,3
+
+    var q = async.queue(function (task, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + task);
+            callback('error', task);
+        }, delays.splice(0,1)[0]);
+    }, 2);
+
+    q.push( [1,2,3,4], function (err, arg) {
+        test.equal(err, 'error');
+        call_order.push('callback ' + arg);
+    });
+
+    test.equal(q.length(), 4);
+    test.equal(q.concurrency, 2);
+
+    setTimeout(function () {
+        test.same(call_order, [
+            'process 2', 'callback 2',
+            'process 1', 'callback 1',
+            'process 4', 'callback 4',
+            'process 3', 'callback 3'
+        ]);
+        test.equal(q.concurrency, 2);
+        test.equal(q.length(), 0);
+        test.done();
+    }, 800);
+};
+
+exports['cargo'] = function (test) {
+    var call_order = [],
+        delays = [160, 160, 80];
+
+    // worker: --12--34--5-
+    // order of completion: 1,2,3,4,5
+
+    var c = async.cargo(function (tasks, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + tasks.join(' '));
+            callback('error', 'arg');
+        }, delays.shift());
+    }, 2);
+
+    c.push(1, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(c.length(), 3);
+        call_order.push('callback ' + 1);
+    });
+    c.push(2, function (err, arg) {
+        test.equal(err, 'error');
+        test.equal(arg, 'arg');
+        test.equal(c.length(), 3);
+        call_order.push('callback ' + 2);
+    });
+
+    test.equal(c.length(), 2);
+
+    // async push
+    setTimeout(function () {
+        c.push(3, function (err, arg) {
+            test.equal(err, 'error');
+            test.equal(arg, 'arg');
+            test.equal(c.length(), 1);
+            call_order.push('callback ' + 3);
+        });
+    }, 60);
+    setTimeout(function () {
+        c.push(4, function (err, arg) {
+            test.equal(err, 'error');
+            test.equal(arg, 'arg');
+            test.equal(c.length(), 1);
+            call_order.push('callback ' + 4);
+        });
+        test.equal(c.length(), 2);
+        c.push(5, function (err, arg) {
+            test.equal(err, 'error');
+            test.equal(arg, 'arg');
+            test.equal(c.length(), 0);
+            call_order.push('callback ' + 5);
+        });
+    }, 120);
+
+
+    setTimeout(function () {
+        test.same(call_order, [
+            'process 1 2', 'callback 1', 'callback 2',
+            'process 3 4', 'callback 3', 'callback 4',
+            'process 5'  , 'callback 5'
+        ]);
+        test.equal(c.length(), 0);
+        test.done();
+    }, 800);
+};
+
+exports['cargo without callback'] = function (test) {
+    var call_order = [],
+        delays = [160,80,240,80];
+
+    // worker: --1-2---34-5-
+    // order of completion: 1,2,3,4,5
+
+    var c = async.cargo(function (tasks, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + tasks.join(' '));
+            callback('error', 'arg');
+        }, delays.shift());
+    }, 2);
+
+    c.push(1);
+
+    setTimeout(function () {
+        c.push(2);
+    }, 120);
+    setTimeout(function () {
+        c.push(3);
+        c.push(4);
+        c.push(5);
+    }, 180);
+
+    setTimeout(function () {
+        test.same(call_order, [
+            'process 1',
+            'process 2',
+            'process 3 4',
+            'process 5'
+        ]);
+        test.done();
+    }, 800);
+};
+
+exports['cargo bulk task'] = function (test) {
+    var call_order = [],
+        delays = [120,40];
+
+    // worker: -123-4-
+    // order of completion: 1,2,3,4
+
+    var c = async.cargo(function (tasks, callback) {
+        setTimeout(function () {
+            call_order.push('process ' + tasks.join(' '));
+            callback('error', tasks.join(' '));
+        }, delays.shift());
+    }, 3);
+
+    c.push( [1,2,3,4], function (err, arg) {
+        test.equal(err, 'error');
+        call_order.push('callback ' + arg);
+    });
+
+    test.equal(c.length(), 4);
+
+    setTimeout(function () {
+        test.same(call_order, [
+            'process 1 2 3', 'callback 1 2 3',
+            'callback 1 2 3', 'callback 1 2 3',
+            'process 4', 'callback 4',
+        ]);
+        test.equal(c.length(), 0);
+        test.done();
+    }, 800);
+};
+
+exports['memoize'] = function (test) {
+    test.expect(4);
+    var call_order = [];
+
+    var fn = function (arg1, arg2, callback) {
+        call_order.push(['fn', arg1, arg2]);
+        callback(null, arg1 + arg2);
+    };
+
+    var fn2 = async.memoize(fn);
+    fn2(1, 2, function (err, result) {
+        test.equal(result, 3);
+    });
+    fn2(1, 2, function (err, result) {
+        test.equal(result, 3);
+    });
+    fn2(2, 2, function (err, result) {
+        test.equal(result, 4);
+    });
+
+    test.same(call_order, [['fn',1,2], ['fn',2,2]]);
+    test.done();
+};
+
+exports['unmemoize'] = function(test) {
+    test.expect(4);
+    var call_order = [];
+
+    var fn = function (arg1, arg2, callback) {
+        call_order.push(['fn', arg1, arg2]);
+        callback(null, arg1 + arg2);
+    };
+
+    var fn2 = async.memoize(fn);
+    var fn3 = async.unmemoize(fn2);
+    fn3(1, 2, function (err, result) {
+        test.equal(result, 3);
+    });
+    fn3(1, 2, function (err, result) {
+        test.equal(result, 3);
+    });
+    fn3(2, 2, function (err, result) {
+        test.equal(result, 4);
+    });
+
+    test.same(call_order, [['fn',1,2], ['fn',1,2], ['fn',2,2]]);
+
+    test.done();
+}
+
+exports['unmemoize a not memoized function'] = function(test) {
+    test.expect(1);
+
+    var fn = function (arg1, arg2, callback) {
+        callback(null, arg1 + arg2);
+    };
+
+    var fn2 = async.unmemoize(fn);
+    fn2(1, 2, function(err, result) {
+        test.equal(result, 3);
+    });
+
+    test.done();
+}
+
+exports['memoize error'] = function (test) {
+    test.expect(1);
+    var testerr = new Error('test');
+    var fn = function (arg1, arg2, callback) {
+        callback(testerr, arg1 + arg2);
+    };
+    async.memoize(fn)(1, 2, function (err, result) {
+        test.equal(err, testerr);
+    });
+    test.done();
+};
+
+exports['memoize multiple calls'] = function (test) {
+    test.expect(3);
+    var fn = function (arg1, arg2, callback) {
+        test.ok(true);
+        setTimeout(function(){
+            callback(null, arg1, arg2);
+        }, 10);
+    };
+    var fn2 = async.memoize(fn);
+    fn2(1, 2, function(err, result) {
+        test.equal(result, 1, 2);
+    });
+    fn2(1, 2, function(err, result) {
+        test.equal(result, 1, 2);
+        test.done();
+    });
+};
+
+exports['memoize custom hash function'] = function (test) {
+    test.expect(2);
+    var testerr = new Error('test');
+
+    var fn = function (arg1, arg2, callback) {
+        callback(testerr, arg1 + arg2);
+    };
+    var fn2 = async.memoize(fn, function () {
+        return 'custom hash';
+    });
+    fn2(1, 2, function (err, result) {
+        test.equal(result, 3);
+    });
+    fn2(2, 2, function (err, result) {
+        test.equal(result, 3);
+    });
+    test.done();
+};
+
+exports['memoize manually added memo value'] = function (test) {
+    test.expect(1);
+    var fn = async.memoize(function(arg, callback) {
+        test(false, "Function should never be called");
+    });
+    fn.memo["foo"] = ["bar"];
+    fn("foo", function(val) {
+        test.equal(val, "bar");
+        test.done();
+    });
+};
+
+// Issue 10 on github: https://github.com/caolan/async/issues#issue/10
+exports['falsy return values in series'] = function (test) {
+    function taskFalse(callback) {
+        async.nextTick(function() {
+            callback(null, false);
+        });
+    };
+    function taskUndefined(callback) {
+        async.nextTick(function() {
+            callback(null, undefined);
+        });
+    };
+    function taskEmpty(callback) {
+        async.nextTick(function() {
+            callback(null);
+        });
+    };
+    function taskNull(callback) {
+        async.nextTick(function() {
+            callback(null, null);
+        });
+    };
+    async.series(
+        [taskFalse, taskUndefined, taskEmpty, taskNull],
+        function(err, results) {
+            test.equal(results.length, 4);
+            test.strictEqual(results[0], false);
+            test.strictEqual(results[1], undefined);
+            test.strictEqual(results[2], undefined);
+            test.strictEqual(results[3], null);
+            test.done();
+        }
+    );
+};
+
+// Issue 10 on github: https://github.com/caolan/async/issues#issue/10
+exports['falsy return values in parallel'] = function (test) {
+    function taskFalse(callback) {
+        async.nextTick(function() {
+            callback(null, false);
+        });
+    };
+    function taskUndefined(callback) {
+        async.nextTick(function() {
+            callback(null, undefined);
+        });
+    };
+    function taskEmpty(callback) {
+        async.nextTick(function() {
+            callback(null);
+        });
+    };
+    function taskNull(callback) {
+        async.nextTick(function() {
+            callback(null, null);
+        });
+    };
+    async.parallel(
+        [taskFalse, taskUndefined, taskEmpty, taskNull],
+        function(err, results) {
+            test.equal(results.length, 4);
+            test.strictEqual(results[0], false);
+            test.strictEqual(results[1], undefined);
+            test.strictEqual(results[2], undefined);
+            test.strictEqual(results[3], null);
+            test.done();
+        }
+    );
+};
+
+exports['queue events'] = function(test) {
+    var calls = [];
+    var q = async.queue(function(task, cb) {
+        // nop
+        calls.push('process ' + task);
+        async.setImmediate(cb);
+    }, 3);
+
+    q.saturated = function() {
+        test.ok(q.length() == 3, 'queue should be saturated now');
+        calls.push('saturated');
+    };
+    q.empty = function() {
+        test.ok(q.length() == 0, 'queue should be empty now');
+        calls.push('empty');
+    };
+    q.drain = function() {
+        test.ok(
+            q.length() == 0 && q.running() == 0,
+            'queue should be empty now and no more workers should be running'
+        );
+        calls.push('drain');
+        test.same(calls, [
+            'saturated',
+            'process foo',
+            'process bar',
+            'process zoo',
+            'foo cb',
+            'process poo',
+            'bar cb',
+            'empty',
+            'process moo',
+            'zoo cb',
+            'poo cb',
+            'moo cb',
+            'drain'
+        ]);
+        test.done();
+    };
+    q.push('foo', function () {calls.push('foo cb');});
+    q.push('bar', function () {calls.push('bar cb');});
+    q.push('zoo', function () {calls.push('zoo cb');});
+    q.push('poo', function () {calls.push('poo cb');});
+    q.push('moo', function () {calls.push('moo cb');});
+};

--- a/src/main/resources/static/bower/async/test/test.html
+++ b/src/main/resources/static/bower/async/test/test.html
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>Async.js Test Suite</title>
+    <!--
+      async must be included after nodeunit because nodeunit already uses
+      the async lib internally and will overwrite the version we want to test
+    -->
+    <script src="../deps/nodeunit.js"></script>
+    <script src="../lib/async.js"></script>
+    <link rel="stylesheet" href="../deps/nodeunit.css" type="text/css" media="screen" />
+    <script>
+      var _async = this.async;
+      this.require = function () { return _async; };
+      this.exports = {};
+    </script>
+    <script src="test-async.js"></script>
+  </head>
+  <body>
+    <h1 id="nodeunit-header">Async.js Test Suite</h1>
+    <script>
+      nodeunit.run({'test-async': exports});
+    </script>
+  </body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -29,6 +29,7 @@
 	<script type="text/javascript" src="bower/angular-sanitize/angular-sanitize.min.js"></script>
 	<script type="text/javascript" src="bower/angular-bootstrap/ui-bootstrap.min.js"></script>
 	<script type="text/javascript" src="bower/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
+	<script type="text/javascript" src="bower/async/lib/async.js"></script>
 
 	<!-- TODO Use ocLazyLoad to load the controllers dynamically -->
 	<!-- https://github.com/ocombe/ocLazyLoad -->

--- a/src/main/resources/static/view/home/home.html
+++ b/src/main/resources/static/view/home/home.html
@@ -1,45 +1,52 @@
-<div id="page-spinner-panel" ng-hide="serviceGroups">
-	<i class="fa fa-spinner fa-spin fa-5x"></i>
+<div class="page-header">
+	<h1>Seiso</h1>
 </div>
-<div ng-show="serviceGroups">
-	<div class="page-header">
-		<h1>Seiso</h1>
-	</div>
-	<section>
-		<header>
-			<h1>Services by group</h1>
-		</header>
-		<div class="row">
-			<div class="col-md-8">
-				<accordion close-others="true">
-					<accordion-group is-open="status.open" ng-repeat="group in serviceGroups" style="opacity:0.8">
-						<accordion-heading>
-							{{group.name}} <i class="pull-right glyphicon" ng-class="{'glyphicon-chevron-down': status.open, 'glyphicon-chevron-right': !status.open}"></i>
-						</accordion-heading>
-						<div ng-if="group.services.length === 0">
-							<p>No services.</p>
-						</div>
-						<div ng-if="group.services.length &gt; 0">
-							<div class="row">
-								<div class="col-md-6">
-									<ul class="list-unstyled">
-										<li ng-repeat="service in group.services.slice(0, (group.services.length + 1) / 2)">
-											<a ng-href="{{uri('services', service.key)}}">{{service.name}}</a>
-										</li>
-									</ul>
-								</div>
-								<div class="col-md-6">
-									<ul class="list-unstyled">
-										<li ng-repeat="service in group.services.slice((group.services.length + 1) / 2, group.services.length)">
-											<a ng-href="{{uri('services', service.key)}}">{{service.name}}</a>
-										</li>
-									</ul>
-								</div>
-							</div>
-						</div>
-					</accordion-group>
-				</accordion>
+<section>
+	<header>
+		<h1>
+			Services by Group
+			<span ng-show="serviceStatus == 'loading'"><i class="fa fa-spinner fa-spin"></i></span>
+		</h1>
+	</header>
+	<div ng-switch="serviceStatus">
+		<div ng-switch-when="error">
+			<div class="alert alert-warning">
+				<i class="fa fa-times-circle"></i> Couldn't load services.
 			</div>
 		</div>
-	</section>
-</div>
+		<div ng-switch-when="loaded">
+			<div class="row">
+				<div class="col-md-8">
+					<accordion close-others="true">
+						<accordion-group is-open="status.open" ng-repeat="group in serviceGroups" style="opacity:0.8">
+							<accordion-heading>
+								{{group.name}} <i class="pull-right glyphicon" ng-class="{'glyphicon-chevron-down': status.open, 'glyphicon-chevron-right': !status.open}"></i>
+							</accordion-heading>
+							<div ng-if="group.services.length === 0">
+								<p>No services.</p>
+							</div>
+							<div ng-if="group.services.length &gt; 0">
+								<div class="row">
+									<div class="col-md-6">
+										<ul class="list-unstyled">
+											<li ng-repeat="service in group.services.slice(0, (group.services.length + 1) / 2)">
+												<a ng-href="{{uri('services', service.key)}}">{{service.name}}</a>
+											</li>
+										</ul>
+									</div>
+									<div class="col-md-6">
+										<ul class="list-unstyled">
+											<li ng-repeat="service in group.services.slice((group.services.length + 1) / 2, group.services.length)">
+												<a ng-href="{{uri('services', service.key)}}">{{service.name}}</a>
+											</li>
+										</ul>
+									</div>
+								</div>
+							</div>
+						</accordion-group>
+					</accordion>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>

--- a/src/main/resources/static/view/items/data-center/details/load-balancer-list.html
+++ b/src/main/resources/static/view/items/data-center/details/load-balancer-list.html
@@ -5,7 +5,7 @@
 			<i class="fa fa-times-circle"></i> Couldn't get load balancers.
 		</div>
 	</div>
-	<div ng-switch="loaded">
+	<div ng-switch-when="loaded">
 		<div ng-if="loadBalancers.length == 0">
 			<div class="alert alert-info">
 				<i class="fa fa-info-circle"></i> No load balancers.


### PR DESCRIPTION
Currently Seiso's JavaScript is written in an imperative style, owing
largely my inexperience with functional programming idioms. This commit
includes two changes of note.

First, in homeController, I replaced the for loops with forEach() calls,
which is more in the functional paradigm. Not sure that what I did is
idiomatic yet, so happy to take suggestions, but the thought is that we
migrate more of the code in this direction.

Second, again in homeController, I'm now using async.map() to effect a
fork/join for the calls to the API. Previousy I was making the calls in
parallel, but wasn't joining, and so occasionally the service groups
would be empty when the call to /v1/services completed first.